### PR TITLE
[ClassicFlang] [Driver] Reduce downstream delta

### DIFF
--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -62,7 +62,6 @@ public:
     AnalyzeJobClass,
     MigrateJobClass,
     CompileJobClass,
-    FortranFrontendJobClass,
     BackendJobClass,
     AssembleJobClass,
     LinkJobClass,
@@ -452,16 +451,6 @@ public:
 
   static bool classof(const Action *A) {
     return A->getKind() == MigrateJobClass;
-  }
-};
-
-class FortranFrontendJobAction : public JobAction {
-  void anchor() override;
-public:
-  FortranFrontendJobAction(Action *Input, types::ID OutputType);
-
-  static bool classof(const Action *A) {
-    return A->getKind() == FortranFrontendJobClass;
   }
 };
 

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -183,7 +183,11 @@ public:
 
   /// Whether the driver should invoke flang for fortran inputs.
   /// Other modes fall back to calling gcc which in turn calls gfortran.
+#ifdef ENABLE_CLASSIC_FLANG
+  bool IsFlangMode() const { return true; }
+#else
   bool IsFlangMode() const { return Mode == FlangMode; }
+#endif
 
   /// Only print tool bindings, don't build any jobs.
   unsigned CCCPrintBindings : 1;

--- a/clang/include/clang/Driver/Phases.h
+++ b/clang/include/clang/Driver/Phases.h
@@ -17,7 +17,6 @@ namespace phases {
   enum ID {
     Preprocess,
     Precompile,
-    FortranFrontend,
     Compile,
     Backend,
     Assemble,

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -135,7 +135,6 @@ private:
 
   mutable std::unique_ptr<Tool> Clang;
   mutable std::unique_ptr<Tool> Flang;
-  mutable std::unique_ptr<Tool> FortranFrontend;
   mutable std::unique_ptr<Tool> Assemble;
   mutable std::unique_ptr<Tool> Link;
   mutable std::unique_ptr<Tool> IfsMerge;
@@ -144,7 +143,6 @@ private:
 
   Tool *getClang() const;
   Tool *getFlang() const;
-  Tool *getFortranFrontend() const;
   Tool *getAssemble() const;
   Tool *getLink() const;
   Tool *getIfsMerge() const;

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -72,10 +72,10 @@ TYPE("ada",                      Ada,          INVALID,         nullptr,  phases
 TYPE("assembler",                PP_Asm,       INVALID,         "s",      phases::Assemble, phases::Link)
 TYPE("assembler-with-cpp",       Asm,          PP_Asm,          "S",      phases::Preprocess, phases::Assemble, phases::Link)
 #ifdef ENABLE_CLASSIC_FLANG
-TYPE("f77",                      PP_F_FixedForm, INVALID,       "f",      phases::FortranFrontend, phases::Backend, phases::Assemble, phases::Link)
-TYPE("f77-cpp-input",            F_FixedForm,  PP_F_FixedForm,  "F",      phases::FortranFrontend, phases::Backend, phases::Assemble, phases::Link)
-TYPE("f95",                      PP_F_FreeForm, INVALID,        "f95",    phases::FortranFrontend, phases::Backend, phases::Assemble, phases::Link)
-TYPE("f95-cpp-input",            F_FreeForm,   PP_F_FreeForm,   "F95",    phases::FortranFrontend, phases::Backend, phases::Assemble, phases::Link)
+TYPE("f77",                      PP_F_FixedForm, INVALID,       "f",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("f77-cpp-input",            F_FixedForm,  PP_F_FixedForm,  "F",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("f95",                      PP_F_FreeForm, INVALID,        "f95",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+TYPE("f95-cpp-input",            F_FreeForm,   PP_F_FreeForm,   "F95",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 #else
 TYPE("f95",                      PP_Fortran,   INVALID,         nullptr,  phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("f95-cpp-input",            Fortran,      PP_Fortran,      nullptr,  phases::Preprocess, phases::Compile, phases::Backend, phases::Assemble, phases::Link)

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -28,7 +28,6 @@ const char *Action::getClassName(ActionClass AC) {
   case HeaderModulePrecompileJobClass: return "header-module-precompiler";
   case AnalyzeJobClass: return "analyzer";
   case MigrateJobClass: return "migrator";
-  case FortranFrontendJobClass: return "fortran-frontend";
   case CompileJobClass: return "compiler";
   case BackendJobClass: return "backend";
   case AssembleJobClass: return "assembler";
@@ -345,12 +344,6 @@ void MigrateJobAction::anchor() {}
 
 MigrateJobAction::MigrateJobAction(Action *Input, types::ID OutputType)
     : JobAction(MigrateJobClass, Input, OutputType) {}
-
-void FortranFrontendJobAction::anchor() {}
-
-FortranFrontendJobAction::FortranFrontendJobAction(Action *Input,
-                                             types::ID OutputType)
-    : JobAction(FortranFrontendJobClass, Input, OutputType) {}
 
 void CompileJobAction::anchor() {}
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -271,23 +271,13 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
 
   // -{E,EP,P,M,MM} only run the preprocessor.
   if (CCCIsCPP() || (PhaseArg = DAL.getLastArg(options::OPT_E)) ||
-#ifdef ENABLE_CLASSIC_FLANG
-      (PhaseArg = DAL.getLastArg(options::OPT_fsyntax_only)) ||
-#endif
       (PhaseArg = DAL.getLastArg(options::OPT__SLASH_EP)) ||
       (PhaseArg = DAL.getLastArg(options::OPT_M, options::OPT_MM)) ||
       (PhaseArg = DAL.getLastArg(options::OPT__SLASH_P))) {
 #ifdef ENABLE_CLASSIC_FLANG
-    // -fsyntax-only or -E stops Fortran compilation after FortranFrontend
-    if (IsFlangMode() && (DAL.getLastArg(options::OPT_E) ||
-      DAL.getLastArg(options::OPT_fsyntax_only))) {
-      FinalPhase = phases::FortranFrontend;
-
-      // if not Fortran, fsyntax_only implies 'Compile' is the FinalPhase
-    } else if (DAL.getLastArg(options::OPT_fsyntax_only)) {
+    if (IsFlangMode() && DAL.getLastArg(options::OPT_E)) {
+      // Fortran is preprocessed using the frontend.
       FinalPhase = phases::Compile;
-
-      // everything else has 'Preprocess' as its FinalPhase
     } else {
       FinalPhase = phases::Preprocess;
     }
@@ -299,14 +289,9 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
   } else if ((PhaseArg = DAL.getLastArg(options::OPT__precompile))) {
     FinalPhase = phases::Precompile;
 
-#ifdef ENABLE_CLASSIC_FLANG
-  // -{analyze,emit-ast} only run up to the compiler.
-  } else if ((PhaseArg = DAL.getLastArg(options::OPT_print_supported_cpus)) ||
-#else
   // -{fsyntax-only,-analyze,emit-ast} only run up to the compiler.
   } else if ((PhaseArg = DAL.getLastArg(options::OPT_fsyntax_only)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_print_supported_cpus)) ||
-#endif
              (PhaseArg = DAL.getLastArg(options::OPT_module_file_info)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_verify_pch)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_rewrite_objc)) ||
@@ -3306,10 +3291,13 @@ void Driver::handleArguments(Compilation &C, DerivedArgList &Args,
       if (InputArg->isClaimed())
         continue;
 
+#ifdef ENABLE_CLASSIC_FLANG
       // Fortran input is preprocessed using the frontend.
-      if (InitialPhase == phases::FortranFrontend &&
-          FinalPhase == phases::Preprocess)
+      if (InitialPhase == phases::Compile &&
+          FinalPhase == phases::Preprocess) {
         continue;
+      }
+#endif
 
       // Claim here to avoid the more general unused warning.
       InputArg->claim();
@@ -3677,13 +3665,6 @@ Action *Driver::ConstructPhaseAction(
                                                            ModName);
     return C.MakeAction<PrecompileJobAction>(Input, OutputTy);
   }
-  case phases::FortranFrontend: {
-    if (Args.hasArg(options::OPT_fsyntax_only))
-      return C.MakeAction<FortranFrontendJobAction>(Input,
-                                                    types::TY_Nothing);
-    return C.MakeAction<FortranFrontendJobAction>(Input,
-                                                  types::TY_LLVM_IR);
-  }
   case phases::Compile: {
     if (Args.hasArg(options::OPT_fsyntax_only))
       return C.MakeAction<CompileJobAction>(Input, types::TY_Nothing);
@@ -3702,6 +3683,8 @@ Action *Driver::ConstructPhaseAction(
       return C.MakeAction<CompileJobAction>(Input, types::TY_ModuleFile);
     if (Args.hasArg(options::OPT_verify_pch))
       return C.MakeAction<VerifyPCHJobAction>(Input, types::TY_Nothing);
+    if (IsFlangMode())
+      return C.MakeAction<CompileJobAction>(Input, types::TY_LLVM_IR);
     return C.MakeAction<CompileJobAction>(Input, types::TY_LLVM_BC);
   }
   case phases::Backend: {

--- a/clang/lib/Driver/Phases.cpp
+++ b/clang/lib/Driver/Phases.cpp
@@ -16,7 +16,6 @@ const char *phases::getPhaseName(ID Id) {
   switch (Id) {
   case Preprocess: return "preprocessor";
   case Precompile: return "precompiler";
-  case FortranFrontend: return "fortran-frontend";
   case Compile: return "compiler";
   case Backend: return "backend";
   case Assemble: return "assembler";

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -259,7 +259,11 @@ Tool *ToolChain::getClang() const {
 
 Tool *ToolChain::getFlang() const {
   if (!Flang)
+#ifdef ENABLE_CLASSIC_FLANG
+    Flang.reset(new tools::ClassicFlang(*this));
+#else
     Flang.reset(new tools::Flang(*this));
+#endif
   return Flang.get();
 }
 
@@ -275,16 +279,6 @@ Tool *ToolChain::getAssemble() const {
   if (!Assemble)
     Assemble.reset(buildAssembler());
   return Assemble.get();
-}
-
-Tool *ToolChain::getFortranFrontend() const {
-#ifdef ENABLE_CLASSIC_FLANG
-  if (!FortranFrontend)
-    FortranFrontend.reset(new tools::ClassicFlang(*this));
-  return FortranFrontend.get();
-#else
-  llvm_unreachable("Fortran is not supported by this toolchain");
-#endif
 }
 
 Tool *ToolChain::getClangAs() const {
@@ -352,9 +346,6 @@ Tool *ToolChain::getTool(Action::ActionClass AC) const {
 
   case Action::OffloadWrapperJobClass:
     return getOffloadWrapper();
-
-  case Action::FortranFrontendJobClass:
-    return getFortranFrontend();
   }
 
   llvm_unreachable("Invalid tool kind.");

--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -376,7 +376,7 @@ void types::getCompilationPhases(const clang::driver::Driver &Driver,
     llvm::copy_if(PhaseList, std::back_inserter(P),
                   [&](phases::ID Phase) {
                     return (Phase <= phases::Preprocess ||
-                            (Phase == phases::FortranFrontend &&
+                            (Phase == phases::Compile &&
                              Driver.IsFlangMode()));
                   });
 #else


### PR DESCRIPTION
This commit is motivated by reducing the merge burden by shrinking the diff
between llvm upstream and classic-flang-llvm-project.

Outside of Flang, fortran code is fed through the Compile phase, and the
appropriate tooling is picked up through ToolChain::SelectTool.

Classic flang introduced a FortranFrontend, but these days this seems
unnecessary. Fortran can go through the same machinary as everything else.

The main thing classic flang does differently is to have the compiler phase do
the preprocessing.

* Use the Compile phase to compile fortran code.
* Remove FortranFrontendJobClass.
* Remove FortranFrontend tool (instead it's just the Flang tool, which in
  classic flang mode is classic flang).
* When compiling with USE_CLASSIC_FLANG, assume IsFlangMode == true.
  * This makes the driver go through the "new" fortran code paths rather than
    the old gfortran/gnu fallback in ToolChain::SelectTool.
* Update a test which inspects the output of the flang tooling.
  * Previously the Compile stage emitted IR. In the interests of avoiding an
    increase of the delta from upstream llvm-project, follow what they do and
    pass bitcode downwards.

# Status

This PR is draft and I've run out of time for it, so it's up for adoption.. It doesn't yet give a correct result (`make check-clang-flang-driver`), I believe because the driver thinks flang is capable of emitting assembly, and therefore combines the stages incorrectly. Please see [my comments here](https://github.com/flang-compiler/classic-flang-llvm-project/pull/1#issuecomment-705598317).