### PR TITLE
Github Actions to build release_11x

### DIFF
--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -2,7 +2,7 @@ name: Pre-compile llvm
 
 on:
   push:
-    branches: [ release_100 ]
+    branches: [ release_100, release_11x ]
 
 jobs:
   build:
@@ -51,13 +51,17 @@ jobs:
           ${{ matrix.cc }}-${{ matrix.version }} --version
           ${{ matrix.cpp }}-${{ matrix.version }} --version
       
+      - name: Extract branch name
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        id: extract_branch
+
       - name: Build llvm
         run: |
           # exit the llvm dir, so the path is the same on subsequent projects
           cd ../..
           rm -rf classic-flang-llvm-project
           # clone manually, because checkout does not allow exiting llvm dir
-          git clone --depth 1 --single-branch --branch release_100 https://github.com/flang-compiler/classic-flang-llvm-project.git
+          git clone --depth 1 --single-branch --branch ${{ steps.extract_branch.outputs.branch }} https://github.com/flang-compiler/classic-flang-llvm-project.git
           cd classic-flang-llvm-project
           # After build place the artifacts in classic-flang-llvm-project/classic-flang-llvm-project, so Upload can find them.
           mkdir classic-flang-llvm-project
@@ -82,5 +86,5 @@ jobs:
       - name: Upload llvm
         uses: actions/upload-artifact@v2
         with:
-          name: llvm_build_${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.version }}
+          name: llvm_build_${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.version }}_${{ steps.extract_branch.outputs.branch }}
           path: llvm_build.tar.gz


### PR DESCRIPTION
Add `release_11x` to CI scripts. 
`release_100` is still build the same way. 
Artifacts have branch name suffix for `flang` CI to be able to distinguish them.