### PR TITLE
Add ccache support to GitHub Actions

### DIFF
--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'clang/**'
       - 'llvm/**'
+      - '.github/workflows/clang-tests.yml'
 
 jobs:
   build_clang:

--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -33,7 +33,7 @@ jobs:
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1
       with:
-        key: ${{ matrix.cc }}-${{ matrix.version }}
+        key: ${{ matrix.os }}
     - name: Test clang
       uses: llvm/actions/build-test-llvm-project@main
       with:

--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -26,7 +26,7 @@ jobs:
           - macOS-latest
     steps:
     - name: Install Ninja
-      uses: llvm/actions/install-ninja@master
+      uses: llvm/actions/install-ninja@main
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
@@ -35,7 +35,7 @@ jobs:
       with:
         key: ${{ matrix.cc }}-${{ matrix.version }}
     - name: Test clang
-      uses: llvm/actions/build-test-llvm-project@master
+      uses: llvm/actions/build-test-llvm-project@main
       with:
         cmake_args: -G Ninja  -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         build_target: check-clang

--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Test clang
       uses: llvm/actions/build-test-llvm-project@main
       with:
-        cmake_args: -G Ninja  -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake_args: -G Ninja -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         build_target: check-clang

--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -29,8 +29,12 @@ jobs:
     - uses: actions/checkout@v1
       with:
         fetch-depth: 1
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: ${{ matrix.cc }}-${{ matrix.version }}
     - name: Test clang
       uses: llvm/actions/build-test-llvm-project@master
       with:
-        cmake_args: -G Ninja  -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release
+        cmake_args: -G Ninja  -DLLVM_ENABLE_PROJECTS="clang" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         build_target: check-clang


### PR DESCRIPTION
This will likely spill over the default limit of 500MB, but would like to gather stats first.