### PR TITLE
[AsmPrinter] Fix redundant names and types

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -155,13 +155,10 @@ DIE *DwarfCompileUnit::getOrCreateGlobalVariableDIE(
   } else {
     DeclContext = GV->getScope();
     // Add name and type.
-    addString(*VariableDIE, dwarf::DW_AT_name, GV->getDisplayName());
-    if (GTy)
-      addType(*VariableDIE, GTy);
-
     if (!GV->getDisplayName().empty())
       addString(*VariableDIE, dwarf::DW_AT_name, GV->getDisplayName());
-    addType(*VariableDIE, GTy);
+    if (GTy)
+      addType(*VariableDIE, GTy);
 
     // Add scoping info.
     if (!GV->isLocalToUnit())


### PR DESCRIPTION
A bug was introduced in 82b38d24a51871a210a184dd558e9b955a421e8e while
cherry-picking a DIGlobalVariable-related patch.