### PR TITLE
[DebugInfo] -gpubnames option support in Driver

### DIFF
--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -329,16 +329,16 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Last argument of -g/-gdwarfX should be taken.
   Arg *GArg = Args.getLastArg(options::OPT_g_Flag);
-  Arg *GDwarfArg = Args.getLastArg(options::OPT_gdwarf_2,
-                                   options::OPT_gdwarf_3,
-                                   options::OPT_gdwarf_4,
-                                   options::OPT_gdwarf_5);
+  Arg *GDwarfArg = Args.getLastArg(options::OPT_gdwarf_2, options::OPT_gdwarf_3,
+                                   options::OPT_gdwarf_4, options::OPT_gdwarf_5,
+                                   options::OPT_gpubnames);
 
   if (GArg || GDwarfArg) {
 
-    for (auto Arg : Args.filtered(options::OPT_g_Flag, options::OPT_gdwarf_2,
-                                  options::OPT_gdwarf_3, options::OPT_gdwarf_4,
-                                  options::OPT_gdwarf_5)) {
+    for (auto Arg :
+         Args.filtered(options::OPT_g_Flag, options::OPT_gdwarf_2,
+                       options::OPT_gdwarf_3, options::OPT_gdwarf_4,
+                       options::OPT_gdwarf_5, options::OPT_gpubnames)) {
       Arg->claim();
     }
 
@@ -355,6 +355,9 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
       CommonCmdArgs.push_back("0x1000000");
     else if (GDwarfArg->getOption().matches(options::OPT_gdwarf_5)) // -gdwarf-5
       CommonCmdArgs.push_back("0x2000000");
+    else if (GDwarfArg->getOption().matches(
+                 options::OPT_gpubnames)) // -gpubnames
+      CommonCmdArgs.push_back("0x40000000");
   }
 
   // -Mipa has no effect


### PR DESCRIPTION
This option controls the production of .debug_names section (in DWARFv5)
and .debug_pubnames section (in DWARFv4).

Flang side support is provided in
flang-compiler/flang#934