### PR TITLE
Allow full path to flang1 and flang2 in classic flang tests.

### DIFF
--- a/clang/test/Driver/flang/classic-flang-must-preprocess.F
+++ b/clang/test/Driver/flang/classic-flang-must-preprocess.F
@@ -5,8 +5,8 @@
 
 ! RUN: %clang --driver-mode=flang -target x86_64-unknown-linux-gnu -c %s -### 2>&1 \
 ! RUN:   | FileCheck %s
-! CHECK: "flang1"
+! CHECK: "{{.*}}flang1"
 ! CHECK-SAME: "-preprocess"
 ! CHECK-SAME: "-nofreeform"
-! CHECK-NEXT: "flang2"
+! CHECK-NEXT: "{{.*}}flang2"
 ! CHECK-NEXT: {{clang.* "-cc1"}}

--- a/clang/test/Driver/flang/classic-flang-must-preprocess.F95
+++ b/clang/test/Driver/flang/classic-flang-must-preprocess.F95
@@ -5,8 +5,8 @@
 
 ! RUN: %clang --driver-mode=flang -target x86_64-unknown-linux-gnu -c %s -### 2>&1 \
 ! RUN:   | FileCheck %s
-! CHECK: "flang1"
+! CHECK: "{{.*}}flang1"
 ! CHECK-SAME: "-preprocess"
 ! CHECK-SAME: "-freeform"
-! CHECK-NEXT: "flang2"
+! CHECK-NEXT: "{{.*}}flang2"
 ! CHECK-NEXT: {{clang.* "-cc1"}}

--- a/clang/test/Driver/flang/classic-flang.f
+++ b/clang/test/Driver/flang/classic-flang.f
@@ -5,10 +5,10 @@
 
 ! RUN: %clang --driver-mode=flang -target x86_64-unknown-linux-gnu -c %s -### 2>&1 \
 ! RUN:   | FileCheck %s
-! CHECK: "flang1"
+! CHECK: "{{.*}}flang1"
 ! CHECK-NOT: "-preprocess"
 ! CHECK-SAME: "-nofreeform"
-! CHECK-NEXT: "flang2"
+! CHECK-NEXT: "{{.*}}flang2"
 ! CHECK-NEXT: {{clang.* "-cc1"}}
 
 ! Check that the driver invokes flang1 correctly when preprocessing is
@@ -16,11 +16,11 @@
 
 ! RUN: %clang --driver-mode=flang -target x86_64-unknown-linux-gnu -E %s -### 2>&1 \
 ! RUN:   | FileCheck --check-prefix=CHECK-PREPROCESS %s
-! CHECK-PREPROCESS: "flang1"
+! CHECK-PREPROCESS: "{{.*}}flang1"
 ! CHECK-PREPROCESS-SAME: "-preprocess"
 ! CHECK-PREPROCESS-SAME: "-es"
 ! CHECK-PREPROCESS-SAME: "-pp"
-! CHECK-PREPROCESS-NOT: "flang1"
-! CHECK-PREPROCESS-NOT: "flang2"
+! CHECK-PREPROCESS-NOT: "{{^.*}}flang1"
+! CHECK-PREPROCESS-NOT: "{{^.*}}flang2"
 ! CHECK-PREPROCESS-NOT: {{clang.* "-cc1"}}
 ! CHECK-PREPROCESS-NOT: {{clang.* "-cc1as"}}

--- a/clang/test/Driver/flang/classic-flang.f95
+++ b/clang/test/Driver/flang/classic-flang.f95
@@ -5,10 +5,10 @@
 
 ! RUN: %clang --driver-mode=flang -target x86_64-unknown-linux-gnu -c %s -### 2>&1 \
 ! RUN:   | FileCheck --check-prefix=CHECK-OBJECT %s
-! CHECK-OBJECT: "flang1"
+! CHECK-OBJECT: "{{.*}}flang1"
 ! CHECK-OBJECT-NOT: "-preprocess"
 ! CHECK-OBJECT-SAME: "-freeform"
-! CHECK-OBJECT-NEXT: "flang2"
+! CHECK-OBJECT-NEXT: "{{.*}}flang2"
 ! CHECK-OBJECT-SAME: "-asm" [[LLFILE:.*.ll]]
 ! CHECK-OBJECT-NEXT: {{clang.* "-cc1"}}
 ! CHECK-OBJECT-SAME: "-o" "classic-flang.o"
@@ -20,12 +20,12 @@
 
 ! RUN: %clang --driver-mode=flang -target x86_64-unknown-linux-gnu -E %s -### 2>&1 \
 ! RUN:   | FileCheck --check-prefix=CHECK-PREPROCESS %s
-! CHECK-PREPROCESS: "flang1"
+! CHECK-PREPROCESS: "{{.*}}flang1"
 ! CHECK-PREPROCESS-SAME: "-preprocess"
 ! CHECK-PREPROCESS-SAME: "-es"
 ! CHECK-PREPROCESS-SAME: "-pp"
-! CHECK-PREPROCESS-NOT: "flang1"
-! CHECK-PREPROCESS-NOT: "flang2"
+! CHECK-PREPROCESS-NOT: "{{.*}}flang1"
+! CHECK-PREPROCESS-NOT: "{{.*}}flang2"
 ! CHECK-PREPROCESS-NOT: {{clang.* "-cc1"}}
 ! CHECK-PREPROCESS-NOT: {{clang.* "-cc1as"}}
 
@@ -34,8 +34,8 @@
 
 ! RUN: %clang --driver-mode=flang -target x86_64-unknown-linux-gnu -integrated-as -S %s -### 2>&1 \
 ! RUN:   | FileCheck --check-prefix=CHECK-ASM %s
-! CHECK-ASM: "flang1"
-! CHECK-ASM-NEXT: "flang2"
+! CHECK-ASM: "{{.*}}flang1"
+! CHECK-ASM-NEXT: "{{.*}}flang2"
 ! CHECK-ASM-SAME: "-asm" [[LLFILE:.*.ll]]
 ! CHECK-ASM-NEXT: {{clang.* "-cc1"}}
 ! CHECK-ASM-SAME: "-o" "classic-flang.s"


### PR DESCRIPTION
When testing @bryanpkc 's release_12x branch I noticed the four tests were failing for me because the call to flang1 and flang2 contained a full path of the tool, e.g. `/usr/bin/local/flang1`. Somehow this failed to match:

```
! CHECK: "flang1"
```

I tried building with different cmake, make, ninja, gcc and clang version and tried building completely outside of the source tree, just outside llvm or using the main cmake script as indicated in the llvm-project instructions - always with the same result.

I do not see any reason why this should be considered an invalid call so I propose we add a wildcard to the beginning of the expected string to indicate that this is OK.