### PR TITLE
Remove unnecessary caret from path in classic-flang test

### DIFF
--- a/clang/test/Driver/flang/classic-flang.f
+++ b/clang/test/Driver/flang/classic-flang.f
@@ -20,7 +20,7 @@
 ! CHECK-PREPROCESS-SAME: "-preprocess"
 ! CHECK-PREPROCESS-SAME: "-es"
 ! CHECK-PREPROCESS-SAME: "-pp"
-! CHECK-PREPROCESS-NOT: "{{^.*}}flang1"
-! CHECK-PREPROCESS-NOT: "{{^.*}}flang2"
+! CHECK-PREPROCESS-NOT: "{{.*}}flang1"
+! CHECK-PREPROCESS-NOT: "{{.*}}flang2"
 ! CHECK-PREPROCESS-NOT: {{clang.* "-cc1"}}
 ! CHECK-PREPROCESS-NOT: {{clang.* "-cc1as"}}


### PR DESCRIPTION
Addressing @bryanpkc 's [review remark](https://github.com/flang-compiler/classic-flang-llvm-project/pull/27#discussion_r596377457) before we forget about it.
Sorry for polluting the commit history.