### PR TITLE
Remove the builds for gcc-9

### DIFF
--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -12,12 +12,8 @@ jobs:
         target: [X86]
         cc: [clang]
         cpp: [clang++]
-        version: [9, 10, 11]
+        version: [10, 11]
         include:
-          - target: X86
-            cc: gcc
-            cpp: g++
-            version: 9
           - target: X86
             cc: gcc
             cpp: g++


### PR DESCRIPTION
This is a consequence of https://github.com/flang-compiler/flang/pull/1012. We don't need the gcc-9 builds any more.
I intentionally left the checks for gcc version, even though we now only use gcc-10, in case we want to add gcc-11 in the future.