### PR TITLE
Remove the builds for gcc-9 and llvm-9

### DIFF
--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -12,12 +12,8 @@ jobs:
         target: [X86]
         cc: [clang]
         cpp: [clang++]
-        version: [9, 10, 11]
+        version: [10, 11]
         include:
-          - target: X86
-            cc: gcc
-            cpp: g++
-            version: 9
           - target: X86
             cc: gcc
             cpp: g++


### PR DESCRIPTION
Cloning https://github.com/flang-compiler/classic-flang-llvm-project/pull/33 to other branches to 1) trigger CI and 2) have the same Github Actions script everywhere.