### PR TITLE
Build and test Flang project on PRs

### DIFF
--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -1,0 +1,126 @@
+name: Build and test Flang
+
+on:
+  pull_request:
+    branches: [ release_100, release_11x, release_12x ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      install_prefix: /usr/local
+    strategy:
+      matrix:
+        target: [X86]
+        cc: [clang]
+        cpp: [clang++]
+        version: [10, 11]
+        include:
+          - target: X86
+            cc: gcc
+            cpp: g++
+            version: 10
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - if: matrix.cc == 'clang'
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
+          sudo touch /etc/apt/sources.list.d/llvm.list
+          echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | sudo tee -a /etc/apt/sources.list.d/llvm.list
+          echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'  | sudo tee -a /etc/apt/sources.list.d/llvm.list
+          wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+          sudo apt update
+          sudo apt install -f -y llvm-${{ matrix.version }} clang-${{ matrix.version}}
+
+      - if: matrix.cc == 'gcc' && matrix.version == '10'
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
+          sudo apt install gcc-10 g++-10
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 10
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 20
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 10
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 20
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: key-${{ matrix.cc }}-${{ matrix.version }}
+
+      - name: Check tools
+        run: |
+          git --version
+          cmake --version
+          make --version
+          ${{ matrix.cc }}-${{ matrix.version }} --version
+          ${{ matrix.cpp }}-${{ matrix.version }} --version
+
+      - name: Build llvm
+        run: |
+          mkdir -p build && cd build
+          # Pass the options directly, to avoid issues with quotation marks
+          cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.cc }}-${{ matrix.version }} \
+            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }}-${{ matrix.version }} \
+            -DLLVM_ENABLE_PROJECTS="clang;openmp" \
+            -DLLVM_ENABLE_CLASSIC_FLANG=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ../llvm
+          make -j$(nproc)
+          sudo make install
+
+      - name: Checkout flang
+        run: |
+          cd ../..
+          git clone --depth 1 --single-branch --branch master https://github.com/flang-compiler/flang.git
+          cd flang
+          mkdir -p build && cd build
+
+      - name: Build libpgmath
+        run: |
+          CMAKE_OPTIONS="-DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
+            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          cd ../../flang/runtime/libpgmath
+          mkdir -p build && cd build
+          cmake $CMAKE_OPTIONS ..
+          make -j$(nproc)
+          sudo make install
+
+      - name: Build Flang
+        run: |
+          cd ../../flang
+          mkdir -p build && cd build
+          cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
+            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
+            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
+            -DCMAKE_Fortran_COMPILER=${{ env.install_prefix }}/bin/flang \
+            -DCMAKE_Fortran_COMPILER_ID=Flang \
+            -DFLANG_INCLUDE_DOCS=ON \
+            -DFLANG_LLVM_EXTENSIONS=ON \
+            -DWITH_WERROR=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            ..
+          make -j$(nproc)
+          sudo make install
+
+      - name: Copy llvm-lit
+        run: |
+          cd ../../flang
+          cp ../classic-flang-llvm-project/classic-flang-llvm-project/build/bin/llvm-lit build/bin/.
+
+      - name: Test flang
+        run: |
+          cd ../../flang/build
+          make check-all


### PR DESCRIPTION
As discussed in the Bi-weekly Classic Flang sync - it's a good idea to make sure that changes to `classic-flang-llvm-project` do not break the `flang` CI. This job will run in parallel to the clang and llvm tests and should not take up more time as it is using ccache to speed up the build.
I had some issues with ccache, most likely to a cancelled run that keeps a lock on some key, I hope the issue will be gone in this repo, but in the worst case I will change this to draft.

We are considering more changes to how CI is running, for example moving the commands to bash scripts to allow easy local reproduction of failing cases, but I prefer to introduce changes step by step, to get meaningful reviews.