### PR TITLE
Add missing <limits> header

### DIFF
--- a/llvm/utils/benchmark/src/benchmark_register.h
+++ b/llvm/utils/benchmark/src/benchmark_register.h
@@ -1,6 +1,7 @@
 #ifndef BENCHMARK_REGISTER_H
 #define BENCHMARK_REGISTER_H
 
+#include <limits>
 #include <vector>
 
 #include "check.h"


### PR DESCRIPTION
While working on another Pull-request I noticed the CI is failing. This coincides with Ubuntu-20.04.2 update. I did not manage to reproduce the failure on a local docker repository, even after setting up the exact same tools, that [github mentions](https://github.com/actions/virtual-environments/blob/ubuntu20/20210510.0/images/linux/Ubuntu2004-README.md) to install for their docker image.

The root cause of the failure is that one of the header files is missing the `#include <limits>` clause. Somehow the tools which we are normally using managed to go around it and build fine, but the current github's Ubuntu image has a set of tools which is not able to cover this and revealed the flaw. 

I think the best solution is to add the missing header and not count on the build tools to do this for us.

I submit a separate PR in order not to mix it with the CI changes I am trying to commit in the original PR.