### PR TITLE
Add missing <limits> header

### DIFF
--- a/llvm/utils/benchmark/src/benchmark_register.h
+++ b/llvm/utils/benchmark/src/benchmark_register.h
@@ -3,6 +3,7 @@
 
 #include <limits>
 #include <vector>
+#include <limits>
 
 #include "check.h"
 


### PR DESCRIPTION
While working on another Pull-request I noticed the CI is failing. This coincides with Ubuntu-20.04.2 update. I did not manage to reproduce the failure on a local docker repository, even after setting up the exact same tools, that github mentions to install for their docker image.

The root cause of the failure is that one of the header files is missing the #include <limits> clause. Somehow the tools which we are normally using managed to go around it and build fine, but the current github's Ubuntu image has a set of tools which is not able to cover this and revealed the flaw.

I think the best solution is to add the missing header and not count on the build tools to do this for us.

I submit a separate PR in order not to mix it with the CI changes I am trying to commit in the original PR.

Essentially identical to https://github.com/flang-compiler/classic-flang-llvm-project/pull/42, just for another branch.