### PR TITLE
Allow pre-compile jobs to be trigerred manually.

### DIFF
--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -1,6 +1,7 @@
 name: Pre-compile llvm
 
 on:
+  workflow_dispatch:
   push:
     branches: [ release_100, release_11x ]
 


### PR DESCRIPTION
The `workflow_dispatch` must be visible in the `yml` script present in the repository's default branch, which currently is `release_100` but it will let us run the job on any other branch (`release_11x` or `release12x`).