### PR TITLE
Allow pre-compile jobs to be trigerred manually (release_11x).

### DIFF
--- a/.github/workflows/build_push_docker_image_Ubuntu20.yml
+++ b/.github/workflows/build_push_docker_image_Ubuntu20.yml
@@ -1,6 +1,7 @@
 name: Ubuntu20 Dockerfile image
 
 on:
+  workflow_dispatch:
   push:
     branches: [ release_11x, release_12x ]
     paths-include:

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -1,8 +1,9 @@
 name: Pre-compile llvm
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ release_100, release_11x ]
+    branches: [ release_100, release_11x, release_12x ]
 
 jobs:
   build:


### PR DESCRIPTION
Not urgent at the moment, basically a clone and expansion of #48 . This is just in case we decide to change the default branch to `release_11x` in the future. The `workflow_dispatch` clause must be present on the default branch'es `yml` script.