### PR TITLE
Add build scripts and make CI use them.

### DIFF
--- a/.github/workflows/Ubuntu20Dockerfile
+++ b/.github/workflows/Ubuntu20Dockerfile
@@ -46,18 +46,7 @@ RUN mkdir /home/github/
 RUN mkdir /home/root && cd home/root && \
     git clone --depth 1 --single-branch --branch release_12x https://github.com/flang-compiler/classic-flang-llvm-project.git classic-flang-llvm-project && \
     cd classic-flang-llvm-project && \
-    mkdir -p build && cd build && \
-    cmake -DLLVM_TARGETS_TO_BUILD=AArch64 \
-             -DCMAKE_INSTALL_PREFIX=/home/github/usr/local \
-             -DCMAKE_BUILD_TYPE=Release \
-             -DCMAKE_C_COMPILER=/usr/bin/gcc-10 \
-             -DCMAKE_CXX_COMPILER=/usr/bin/g++-10 \
-             -DLLVM_ENABLE_PROJECTS="clang;openmp" \
-             -DLLVM_ENABLE_CLASSIC_FLANG=ON \
-             ../llvm && \
-    make -j`nproc --ignore=1` && \
-    make install && \
-    make clean
+    ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i
 
 RUN useradd github && \
     chown -R github:github /home/github

--- a/.github/workflows/build_push_docker_image_Ubuntu20.yml
+++ b/.github/workflows/build_push_docker_image_Ubuntu20.yml
@@ -1,4 +1,4 @@
-name: Ubuntu20 Dockerfile image
+name: Pre-compile llvm ARM64
 
 on:
   workflow_dispatch:

--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -56,64 +56,18 @@ jobs:
           ${{ matrix.cc }}-${{ matrix.version }} --version
           ${{ matrix.cpp }}-${{ matrix.version }} --version
 
-      - name: Build llvm
-        run: |
-          mkdir -p build && cd build
-          # Pass the options directly, to avoid issues with quotation marks
-          cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.cc }}-${{ matrix.version }} \
-            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }}-${{ matrix.version }} \
-            -DLLVM_ENABLE_PROJECTS="clang;openmp" \
-            -DLLVM_ENABLE_CLASSIC_FLANG=ON \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ../llvm
-          make -j$(nproc)
-          sudo make install
+      - name: Build and install llvm
+        run: ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -c -i -s
 
       - name: Checkout flang
         run: |
           cd ../..
           git clone --depth 1 --single-branch --branch master https://github.com/flang-compiler/flang.git
-          cd flang
-          mkdir -p build && cd build
 
-      - name: Build libpgmath
-        run: |
-          CMAKE_OPTIONS="-DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
-            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-          cd ../../flang/runtime/libpgmath
-          mkdir -p build && cd build
-          cmake $CMAKE_OPTIONS ..
-          make -j$(nproc)
-          sudo make install
-
-      - name: Build Flang
+      - name: Build and install libpgmath & flang
         run: |
           cd ../../flang
-          mkdir -p build && cd build
-          cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=${{ env.install_prefix }} \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=${{ env.install_prefix }}/bin/clang \
-            -DCMAKE_CXX_COMPILER=${{ env.install_prefix }}/bin/clang++ \
-            -DCMAKE_Fortran_COMPILER=${{ env.install_prefix }}/bin/flang \
-            -DCMAKE_Fortran_COMPILER_ID=Flang \
-            -DFLANG_INCLUDE_DOCS=ON \
-            -DFLANG_LLVM_EXTENSIONS=ON \
-            -DWITH_WERROR=OFF \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            ..
-          make -j$(nproc)
-          sudo make install
+          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc) -c -s
 
       - name: Copy llvm-lit
         run: |

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -62,20 +62,14 @@ jobs:
           cd classic-flang-llvm-project
           # After build place the artifacts in classic-flang-llvm-project/classic-flang-llvm-project, so Upload can find them.
           mkdir classic-flang-llvm-project
-          mkdir -p build && cd build
-          # Pass the options directly, to avoid issues with quotation marks
-          cmake -DLLVM_TARGETS_TO_BUILD=${{ matrix.target }} \
-            -DCMAKE_INSTALL_PREFIX=/usr/local \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=/usr/bin/${{ matrix.cc }}-${{ matrix.version }} \
-            -DCMAKE_CXX_COMPILER=/usr/bin/${{ matrix.cpp }}-${{ matrix.version }} \
-            -DLLVM_ENABLE_PROJECTS="clang;openmp" \
-            -DLLVM_ENABLE_CLASSIC_FLANG=ON \
-            ../llvm
-          make -j$(nproc)
-          
+          ./build-llvm-project.sh \
+            -t ${{ matrix.target }} \
+            -p /usr/local \
+            -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} \
+            -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} \
+            -n $(nproc)
           # Archive the source + build directories for future installation
-          cd ../..
+          cd ..
           tar -zcf llvm_build.tar.gz classic-flang-llvm-project
           # Upload will only look in $GITHUB_WORKSPACE or its subdirs.
           mv llvm_build.tar.gz classic-flang-llvm-project/classic-flang-llvm-project/.

--- a/build-llvm-project.sh
+++ b/build-llvm-project.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Initialize our own variables:
+TARGET="X86"
+INSTALL_PREFIX="/usr/local"
+NPROC=1
+USE_CCACHE="0"
+DO_INSTALL="0"
+USE_SUDO="0"
+C_COMPILER_PATH="/usr/bin/gcc"
+CXX_COMPILER_PATH="/usr/bin/g++"
+
+set -e # Exit script on first error.
+
+function print_usage {
+    echo "Usage: ./build-llvm-project.sh [options]";
+    echo "";
+    echo "Build and install classic-flang-llvm-project.";
+    echo "Run this script in a directory with project sources.";
+    echo "Example:";
+    echo "  $ git clone https://github.com/flang-compiler/classic-flang-llvm-project";
+    echo "  $ cd classic-flang-llvm-project";
+    echo "  $ .github/workflows/build-llvm-project.sh -t X86 -p /install/prefix/ \\";
+    echo "  $ -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i -s";
+    echo "";
+    echo "Options:";
+    echo "  -t  Target to build for (X86, AArch64, PowerPC). Default: X86";
+    echo "  -p  Install prefix. Default: /usr/local";
+    echo "  -n  Number of parallel jobs. Default: 1";
+    echo "  -c  Use ccache. Default: 0 - do not use ccache";
+    echo "  -i  Install the build. Default 0 - just build, do not install";
+    echo "  -s  Use sudo to install. Default: 0 - do not use sudo";
+    echo "  -a  C compiler path. Default: /usr/bin/gcc";
+    echo "  -b  C++ compiler path. Default: /usr/bin/g++";
+}
+while getopts "t:p:n:c?i?s?a:b:" opt; do
+    case "$opt" in
+        t)  TARGET=$OPTARG;;
+        p)  INSTALL_PREFIX=$OPTARG;;
+        n)  NPROC=$OPTARG;;
+        c)  USE_CCACHE="1";;
+        i)  DO_INSTALL="1";;
+        s)  USE_SUDO="1";;
+        a)  C_COMPILER_PATH=$OPTARG;;
+        b)  CXX_COMPILER_PATH=$OPTARG;;
+        ?) print_usage; exit 0;;
+    esac
+done
+
+CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER=$C_COMPILER_PATH \
+    -DCMAKE_CXX_COMPILER=$CXX_COMPILER_PATH \
+    -DLLVM_TARGETS_TO_BUILD=$TARGET \
+    -DLLVM_ENABLE_CLASSIC_FLANG=ON"
+# Warning: the -DLLVM_ENABLE_PROJECTS option is specified with cmake
+# to avoid issues with nested quotation marks
+
+if [ $USE_CCACHE == "1" ]; then
+  echo "Build using ccache"
+  CMAKE_OPTIONS="$CMAKE_OPTIONS \
+      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+fi
+
+# Build and install
+mkdir -p build && cd build
+cmake $CMAKE_OPTIONS -DLLVM_ENABLE_PROJECTS="clang;openmp" ../llvm
+make -j$NPROC
+if [ $DO_INSTALL == "1" ]; then
+  if [ $USE_SUDO == "1" ]; then
+    echo "Install with sudo"
+    sudo make install
+  else
+    echo "Install without sudo"
+    make install
+  fi
+fi
+cd ..
+


### PR DESCRIPTION
This PR can only be merged after https://github.com/flang-compiler/flang/pull/1082. It depends on the newly added `build-flang.sh` script.
WIP: testing with my branch of flang to be able to use the `build-flang.sh` script in CI.

I have no means of testing the AArch64 jobs - we will see if they work fine after the merged commit lands on the `release` branch. I checked on my fork that X86 builds are working fine when landing on `release_12x`