### PR TITLE
Removing CI test-base for release_100 (release_11x)

### DIFF
--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -2,7 +2,7 @@ name: Build and test Flang
 
 on:
   pull_request:
-    branches: [ release_100, release_11x, release_12x ]
+    branches: [ release_11x, release_12x ]
 
 jobs:
   build:


### PR DESCRIPTION
PR depends on https://github.com/flang-compiler/flang/pull/1133
Flang dependency to access this workflow must be removed before this PR gets approved