### PR TITLE
Pass target-attributes to Flang to embed in .ll files

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -301,76 +301,11 @@ static void ParseMPreferVectorWidth(const Driver &D, const ArgList &Args,
   }
 }
 
-static void getWebAssemblyTargetFeatures(const ArgList &Args,
-                                         std::vector<StringRef> &Features) {
-  handleTargetFeaturesGroup(Args, Features, options::OPT_m_wasm_Features_Group);
-}
-
 static void getTargetFeatures(const Driver &D, const llvm::Triple &Triple,
                               const ArgList &Args, ArgStringList &CmdArgs,
                               bool ForAS, bool IsAux = false) {
   std::vector<StringRef> Features;
-  switch (Triple.getArch()) {
-  default:
-    break;
-  case llvm::Triple::mips:
-  case llvm::Triple::mipsel:
-  case llvm::Triple::mips64:
-  case llvm::Triple::mips64el:
-    mips::getMIPSTargetFeatures(D, Triple, Args, Features);
-    break;
-
-  case llvm::Triple::arm:
-  case llvm::Triple::armeb:
-  case llvm::Triple::thumb:
-  case llvm::Triple::thumbeb:
-    arm::getARMTargetFeatures(D, Triple, Args, CmdArgs, Features, ForAS);
-    break;
-
-  case llvm::Triple::ppc:
-  case llvm::Triple::ppcle:
-  case llvm::Triple::ppc64:
-  case llvm::Triple::ppc64le:
-    ppc::getPPCTargetFeatures(D, Triple, Args, Features);
-    break;
-  case llvm::Triple::riscv32:
-  case llvm::Triple::riscv64:
-    riscv::getRISCVTargetFeatures(D, Triple, Args, Features);
-    break;
-  case llvm::Triple::systemz:
-    systemz::getSystemZTargetFeatures(D, Args, Features);
-    break;
-  case llvm::Triple::aarch64:
-  case llvm::Triple::aarch64_32:
-  case llvm::Triple::aarch64_be:
-    aarch64::getAArch64TargetFeatures(D, Triple, Args, Features);
-    break;
-  case llvm::Triple::x86:
-  case llvm::Triple::x86_64:
-    x86::getX86TargetFeatures(D, Triple, Args, Features);
-    break;
-  case llvm::Triple::hexagon:
-    hexagon::getHexagonTargetFeatures(D, Args, Features);
-    break;
-  case llvm::Triple::wasm32:
-  case llvm::Triple::wasm64:
-    getWebAssemblyTargetFeatures(Args, Features);
-    break;
-  case llvm::Triple::sparc:
-  case llvm::Triple::sparcel:
-  case llvm::Triple::sparcv9:
-    sparc::getSparcTargetFeatures(D, Args, Features);
-    break;
-  case llvm::Triple::r600:
-  case llvm::Triple::amdgcn:
-    amdgpu::getAMDGPUTargetFeatures(D, Triple, Args, Features);
-    break;
-  case llvm::Triple::msp430:
-    msp430::getMSP430TargetFeatures(D, Args, Features);
-    break;
-  case llvm::Triple::ve:
-    ve::getVETargetFeatures(D, Args, Features);
-  }
+  getTargetFeatureList(D, Triple, Args, CmdArgs, ForAS, Features);
 
   for (auto Feature : unifyTargetFeatures(Features)) {
     CmdArgs.push_back(IsAux ? "-aux-target-feature" : "-target-feature");

--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -979,11 +979,10 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
   std::string FeatureList = "";
   getTargetFeatureList(D, Triple, Args, UpperCmdArgs, false, Features);
   if (!Features.empty()) {
-    for (unsigned I = 0, N = Features.size(); I < N; ++I) {
-      StringRef Name = Features[I];
-      FeatureList += Name.str();
-      if (I < (N - 1))
+    for (auto Feature : unifyTargetFeatures(Features)) {
+      if (!FeatureList.empty())
         FeatureList += ',';
+      FeatureList += Feature;
     }
 
     LowerCmdArgs.push_back("-target_features");

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -11,12 +11,16 @@
 #include "Arch/ARM.h"
 #include "Arch/Mips.h"
 #include "Arch/PPC.h"
+#include "Arch/RISCV.h"
+#include "Arch/Sparc.h"
 #include "Arch/SystemZ.h"
 #include "Arch/VE.h"
 #include "Arch/X86.h"
+#include "AMDGPU.h"
 #include "HIP.h"
 #include "Hexagon.h"
 #include "InputInfo.h"
+#include "MSP430.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/ObjCRuntime.h"
@@ -234,6 +238,79 @@ void tools::addDirectoryList(const ArgList &Args, ArgStringList &CmdArgs,
       CmdArgs.push_back(ArgName);
       CmdArgs.push_back(Args.MakeArgString(Dirs));
     }
+  }
+}
+
+static void getWebAssemblyTargetFeatures(const ArgList &Args,
+                                         std::vector<StringRef> &Features) {
+  handleTargetFeaturesGroup(Args, Features, options::OPT_m_wasm_Features_Group);
+}
+
+void tools::getTargetFeatureList(const Driver &D,
+                                 const llvm::Triple &Triple,
+                                 const ArgList &Args, ArgStringList &CmdArgs,
+                                 bool ForAS,
+                                 std::vector<StringRef> &Features) {
+  switch (Triple.getArch()) {
+  default:
+    break;
+  case llvm::Triple::mips:
+  case llvm::Triple::mipsel:
+  case llvm::Triple::mips64:
+  case llvm::Triple::mips64el:
+    mips::getMIPSTargetFeatures(D, Triple, Args, Features);
+    break;
+
+  case llvm::Triple::arm:
+  case llvm::Triple::armeb:
+  case llvm::Triple::thumb:
+  case llvm::Triple::thumbeb:
+    arm::getARMTargetFeatures(D, Triple, Args, CmdArgs, Features, ForAS);
+    break;
+
+  case llvm::Triple::ppc:
+  case llvm::Triple::ppcle:
+  case llvm::Triple::ppc64:
+  case llvm::Triple::ppc64le:
+    ppc::getPPCTargetFeatures(D, Triple, Args, Features);
+    break;
+  case llvm::Triple::riscv32:
+  case llvm::Triple::riscv64:
+    riscv::getRISCVTargetFeatures(D, Triple, Args, Features);
+    break;
+  case llvm::Triple::systemz:
+    systemz::getSystemZTargetFeatures(D, Args, Features);
+    break;
+  case llvm::Triple::aarch64:
+  case llvm::Triple::aarch64_32:
+  case llvm::Triple::aarch64_be:
+    aarch64::getAArch64TargetFeatures(D, Triple, Args, Features);
+    break;
+  case llvm::Triple::x86:
+  case llvm::Triple::x86_64:
+    x86::getX86TargetFeatures(D, Triple, Args, Features);
+    break;
+  case llvm::Triple::hexagon:
+    hexagon::getHexagonTargetFeatures(D, Args, Features);
+    break;
+  case llvm::Triple::wasm32:
+  case llvm::Triple::wasm64:
+    getWebAssemblyTargetFeatures(Args, Features);
+    break;
+  case llvm::Triple::sparc:
+  case llvm::Triple::sparcel:
+  case llvm::Triple::sparcv9:
+    sparc::getSparcTargetFeatures(D, Args, Features);
+    break;
+  case llvm::Triple::r600:
+  case llvm::Triple::amdgcn:
+    amdgpu::getAMDGPUTargetFeatures(D, Triple, Args, Features);
+    break;
+  case llvm::Triple::msp430:
+    msp430::getMSP430TargetFeatures(D, Args, Features);
+    break;
+  case llvm::Triple::ve:
+    ve::getVETargetFeatures(D, Args, Features);
   }
 }
 

--- a/clang/lib/Driver/ToolChains/CommonArgs.h
+++ b/clang/lib/Driver/ToolChains/CommonArgs.h
@@ -14,6 +14,7 @@
 #include "clang/Driver/Multilib.h"
 #include "clang/Driver/Tool.h"
 #include "clang/Driver/ToolChain.h"
+#include "llvm/Option/ArgList.h"
 #include "llvm/Support/CodeGen.h"
 
 namespace clang {
@@ -24,6 +25,12 @@ bool needFortranLibs(const Driver &D, const llvm::opt::ArgList &Args);
 
 void addPathIfExists(const Driver &D, const Twine &Path,
                      ToolChain::path_list &Paths);
+
+void getTargetFeatureList(const Driver &D,
+                          const llvm::Triple &Triple,
+                          const llvm::opt::ArgList &Args,
+                          llvm::opt::ArgStringList &CmdArgs,
+                          bool ForAS, std::vector<StringRef> &Features);
 
 void AddLinkerInputs(const ToolChain &TC, const InputInfoList &Inputs,
                      const llvm::opt::ArgList &Args,

--- a/clang/test/Driver/emit-flang-attrs.f90
+++ b/clang/test/Driver/emit-flang-attrs.f90
@@ -2,6 +2,7 @@
 // RUN: %flang -### -target aarch64-linux-gnu -march=armv8-a -c %s 2>&1 | FileCheck --check-prefix=CHECK-ATTRS-NEON %s
 // RUN: %flang -### -target aarch64-linux-gnu -march=armv8-a+sve -c %s 2>&1 | FileCheck --check-prefix=CHECK-ATTRS-SVE %s
 // RUN: %flang -### -target aarch64-linux-gnu -march=armv8-a+nosve -c %s 2>&1 | FileCheck --check-prefix=CHECK-ATTRS-NOSVE %s
+// RUN: %flang -### -target aarch64-linux-gnu -march=armv8-a+sve+nosve -c %s 2>&1 | FileCheck --check-prefix=CHECK-ATTRS-NOSVE %s
 // CHECK-ATTRS-NEON: "{{.*}}flang2"
 // CHECK-ATTRS-NEON-SAME: "-target_features" "+neon"
 // CHECK-ATTRS-SVE: "{{.*}}flang2"

--- a/clang/test/Driver/emit-flang-attrs.f90
+++ b/clang/test/Driver/emit-flang-attrs.f90
@@ -1,0 +1,10 @@
+// REQUIRES: aarch64-registered-target
+// RUN: %flang -### -target aarch64-linux-gnu -march=armv8-a -c %s 2>&1 | FileCheck --check-prefix=CHECK-ATTRS-NEON %s
+// RUN: %flang -### -target aarch64-linux-gnu -march=armv8-a+sve -c %s 2>&1 | FileCheck --check-prefix=CHECK-ATTRS-SVE %s
+// RUN: %flang -### -target aarch64-linux-gnu -march=armv8-a+nosve -c %s 2>&1 | FileCheck --check-prefix=CHECK-ATTRS-NOSVE %s
+// CHECK-ATTRS-NEON: "{{.*}}flang2"
+// CHECK-ATTRS-NEON-SAME: "-target_features" "+neon"
+// CHECK-ATTRS-SVE: "{{.*}}flang2"
+// CHECK-ATTRS-SVE-SAME: "-target_features" "+neon,+sve"
+// CHECK-ATTRS-NOSVE: "{{.*}}flang2"
+// CHECK-ATTRS-NOSVE-SAME: "-target_features" "+neon,-sve"

--- a/clang/test/Driver/fortran-phases.f90
+++ b/clang/test/Driver/fortran-phases.f90
@@ -1,0 +1,100 @@
+! Test to see that the correct phases are run for the commandline input
+
+! RUN: %flang -ccc-print-phases 2>&1 %s | FileCheck %s --check-prefix=LINK-NOPP
+! RUN: %flang -ccc-print-phases -c 2>&1 %s | FileCheck %s --check-prefix=CONLY-NOPP
+! RUN: %flang -ccc-print-phases -S 2>&1 %s | FileCheck %s --check-prefix=AONLY-NOPP
+! RUN: %flang -ccc-print-phases -c -emit-llvm 2>&1 %s | FileCheck %s --check-prefix=LLONLY-NOPP
+! RUN: %flang -ccc-print-phases -S -emit-llvm 2>&1 %s | FileCheck %s --check-prefix=LLONLY-NOPP
+! RUN: %flang -ccc-print-phases -fsyntax-only 2>&1 %s | FileCheck %s --check-prefix=SONLY-NOPP
+! RUN: %flang -ccc-print-phases -E 2>&1 %s | FileCheck %s --check-prefix=PPONLY-NOPP
+
+! RUN: %flang -ccc-print-phases 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=LINK
+! RUN: %flang -ccc-print-phases 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=LINK
+! RUN: %flang -ccc-print-phases -c 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=CONLY
+! RUN: %flang -ccc-print-phases -S 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=AONLY
+! RUN: %flang -ccc-print-phases -c -emit-llvm 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=LLONLY
+! RUN: %flang -ccc-print-phases -S -emit-llvm 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=LLONLY
+! RUN: %flang -ccc-print-phases -fsyntax-only 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=SONLY
+! RUN: %flang -ccc-print-phases -E 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=PPONLY
+
+! LINK-NOPP: 0: input, {{.*}}, f95
+! LINK-NOPP: 1: compiler, {0}, ir
+! LINK-NOPP: 2: backend, {1}, assembler
+! LINK-NOPP: 3: assembler, {2}, object
+! LINK-NOPP: 4: linker, {3}, image
+
+! CONLY-NOPP: 0: input, {{.*}}, f95
+! CONLY-NOPP: 1: compiler, {0}, ir
+! CONLY-NOPP: 2: backend, {1}, assembler
+! CONLY-NOPP: 3: assembler, {2}, object
+! CONLY-NOPP-NOT: 4: linker, {3}, image
+
+! AONLY-NOPP: 0: input, {{.*}}, f95
+! AONLY-NOPP: 1: compiler, {0}, ir
+! AONLY-NOPP: 2: backend, {1}, assembler
+! AONLY-NOPP-NOT: 3: assembler, {2}, object
+! AONLY-NOPP-NOT: 4: linker, {3}, image
+
+! LLONLY-NOPP: 0: input, {{.*}}, f95
+! LLONLY-NOPP: 1: compiler, {0}, ir
+! LLONLY-NOPP-NOT: 2: backend, {1}, assembler
+! LLONLY-NOPP-NOT: 3: assembler, {2}, object
+! LLONLY-NOPP-NOT: 4: linker, {3}, image
+
+! SONLY-NOPP: 0: input, {{.*}}, f95
+! SONLY-NOPP-NOT: 1: compiler, {0}, ir
+! SONLY-NOPP-NOT: 2: backend, {1}, assembler
+! SONLY-NOPP-NOT: 3: assembler, {2}, object
+! SONLY-NOPP-NOT: 4: linker, {3}, image
+
+! PPONLY-NOPP: 0: input, {{.*}}, f95
+! PPONLY-NOPP: 1: compiler, {0}, ir
+! PPONLY-NOPP-NOT: 2: backend, {1}, assembler
+! PPONLY-NOPP-NOT: 3: assembler, {2}, object
+! PPONLY-NOPP-NOT: 4: linker, {3}, image
+
+! LINK: 0: input, {{.*}}, f95-cpp-input
+! LINK: 1: preprocessor, {0}, f95
+! LINK: 2: compiler, {1}, ir
+! LINK: 3: backend, {2}, assembler
+! LINK: 4: assembler, {3}, object
+! LINK: 5: linker, {4}, image
+
+! CONLY: 0: input, {{.*}}, f95-cpp-input
+! CONLY: 1: preprocessor, {0}, f95
+! CONLY: 2: compiler, {1}, ir
+! CONLY: 3: backend, {2}, assembler
+! CONLY: 4: assembler, {3}, object
+! CONLY-NOT: 5: linker, {4}, image
+
+! AONLY: 0: input, {{.*}}, f95-cpp-input
+! AONLY: 1: preprocessor, {0}, f95
+! AONLY: 2: compiler, {1}, ir
+! AONLY: 3: backend, {2}, assembler
+! AONLY-NOT: 4: assembler, {3}, object
+! AONLY-NOT: 5: linker, {4}, image
+
+! LLONLY: 0: input, {{.*}}, f95-cpp-input
+! LLONLY: 1: preprocessor, {0}, f95
+! LLONLY: 2: compiler, {1}, ir
+! LLONLY-NOT: 3: backend, {2}, assembler
+! LLONLY-NOT: 4: assembler, {3}, object
+! LLONLY-NOT: 5: linker, {4}, image
+
+! SONLY: 0: input, {{.*}}, f95-cpp-input
+! SONLY: 1: preprocessor, {0}, f95
+! SONLY-NOT: 2: compiler, {1}, ir
+! SONLY-NOT: 3: backend, {2}, assembler
+! SONLY-NOT: 4: assembler, {3}, object
+! SONLY-NOT: 5: linker, {4}, image
+
+! PPONLY: 0: input, {{.*}}, f95-cpp-input
+! PPONLY: 1: preprocessor, {0}, f95
+! PPONLY: 2: compiler, {1}, ir
+! PPONLY-NOT: 3: backend, {2}, assembler
+! PPONLY-NOT: 4: assembler, {3}, object
+! PPONLY-NOT: 5: linker, {4}, image
+
+program hello
+  write(*, *) "Hello"
+end program hello

--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -27,7 +27,8 @@ class TestingConfig(object):
                      'SANITIZER_IGNORE_CVE_2016_2143', 'TMPDIR', 'TMP', 'TEMP',
                      'TEMPDIR', 'AVRLIT_BOARD', 'AVRLIT_PORT',
                      'FILECHECK_OPTS', 'VCINSTALLDIR', 'VCToolsinstallDir',
-                     'VSINSTALLDIR', 'WindowsSdkDir', 'WindowsSDKLibVersion']
+                     'VSINSTALLDIR', 'WindowsSdkDir', 'WindowsSDKLibVersion',
+                     'FLANG']
 
         if sys.platform == 'win32':
             pass_vars.append('INCLUDE')

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -392,6 +392,8 @@ class LLVMConfig(object):
         just-built or installed clang, and add a set of standard
         substitutions useful to any test suite that makes use of clang.
 
+        Also sets up use of flang
+
         """
         # Clear some environment variables that might affect Clang.
         #
@@ -458,6 +460,14 @@ class LLVMConfig(object):
           self.add_tool_substitutions(tool_substitutions)
           self.config.substitutions.append(
               ('%resource_dir', builtin_include_dir))
+
+        self.config.flang = self.use_llvm_tool(
+            'flang', search_env='FLANG', required=required)
+        if self.config.flang:
+            tool_substitutions = [
+                ToolSubst('%flang', command=self.config.flang)
+                ]
+            self.add_tool_substitutions(tool_substitutions)
 
         self.config.substitutions.append(('%itanium_abi_triple',
                                           self.make_itanium_abi_triple(self.config.target_triple)))


### PR DESCRIPTION
Have the clang driver pass target-attributes through to flang(2) so that they can be embedded in LLVM metadata.

The use case is LTO, where the target features need to be read in from the various inputs by the LTO plugin and merged. For flang, the non-LTO compilation works without this because the call to clang on the resulting .ll file from flang2 has the target-attributes passed to it by the flang driver. For the LTO case, these are need to already be present in the .ll file metadata so flang has to know about them.

I wanted to add a test case so I have include a commit to lit to enable a %flang lit substitution that lets us call it from lit in the clang/test repository. All tests here ought to be written as driver only tests (using `-###` or similar option) because flang1/flang2 are not necessarily available here (although they will be if they can be added to the test environment's $PATH). Added a simple test as proof of concept of this change in addition to the test for the target features.

See https://github.com/flang-compiler/flang/pull/1173 for the flang half.