### PR TITLE
Fix release_13x ARM CI dockerfile

### DIFF
--- a/.github/workflows/Ubuntu20Dockerfile
+++ b/.github/workflows/Ubuntu20Dockerfile
@@ -35,12 +35,11 @@ RUN apt-get install -y software-properties-common && \
     apt-get install -f -y llvm-11 clang-11
 
 # Install the tools for release_13x
-RUN apt-get install -y build-essential manpages-dev \
+RUN apt-get --fix-missing update && \
+    apt-get install -y build-essential manpages-dev \
     libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev libncurses5-dev \
-    libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get install -y gcc-11 g++-11 python python3-distutils
+    libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl
 
 RUN cd /opt && \
     wget https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-aarch64.sh && \
@@ -52,7 +51,7 @@ RUN ln -s /usr/bin/ninja-build /usr/local/bin/ninja
 RUN mkdir /home/github/
 
 RUN mkdir /home/root && cd home/root && \
-    git clone --depth 1 --single-branch --branch release_12x https://github.com/flang-compiler/classic-flang-llvm-project.git classic-flang-llvm-project && \
+    git clone --depth 1 --single-branch --branch release_13x https://github.com/flang-compiler/classic-flang-llvm-project.git classic-flang-llvm-project && \
     cd classic-flang-llvm-project && \
     ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i
 


### PR DESCRIPTION
Removed some repeated packages. Aside that, I cannot reproduce the issue, I tried with ARM64 QEMU and ARM64 Graviton machine (AWS). From the logs I noticed that the issue is that it cannot reach some packages, so maybe is related to the version of Ubuntu base that the server is using, however I cannot tell since I don't have access to the faulty machine. 
I added to the dockerfile an "apt-get --fix-missing" to try to fix any missing link. These are the problematic packages:
```
Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/m/mesa/libglapi-mesa_21.0.3-0ubuntu0.3~20.04.3_arm64.deb  404  Not Found [IP: 91.189.88.152 80]
Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/m/mesa/libgl1-mesa-dri_21.0.3-0ubuntu0.3~20.04.3_arm64.deb  404  Not Found [IP: 91.189.88.152 80]
Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/m/mesa/libglx-mesa0_21.0.3-0ubuntu0.3~20.04.3_arm64.deb  404  Not Found [IP: 91.189.88.152 80]
Failed to fetch http://ports.ubuntu.com/ubuntu-ports/pool/main/m/mesa/mesa-vulkan-drivers_21.0.3-0ubuntu0.3~20.04.3_arm64.deb  404  Not Found [IP: 91.189.88.152 80]
```
For example, this package is currently available:
http://ports.ubuntu.com/ubuntu-ports/pool/main/m/mesa/libglapi-mesa_21.0.3-0ubuntu0.3~20.04.5_arm64.deb

But all the invocations for apt-get update would fix that, so I don't know why is looking for a package that is old. The --fix-missing is aim to do that

The added packages for release_13x doesn't add those vulkan/mesa packages, in fact the extra packages are aim to build the extra drivers needed to run some llvm tests. Eventually those could be removed if needed, however tests will fail due some dependencies are not meet.

I cannot test it further, the AWS server I'm using is a basic one without too much CPU power and limited HDD size, however llvm is able to compile.