### PR TITLE
Add -emit-flang-llvm option

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1041,6 +1041,8 @@ def d_Flag : Flag<["-"], "d">, Group<d_Group>;
 def d_Joined : Joined<["-"], "d">, Group<d_Group>;
 def emit_ast : Flag<["-"], "emit-ast">,
   HelpText<"Emit Clang AST files for source inputs">;
+def emit_flang_llvm : Flag<["-"], "emit-flang-llvm">,
+  HelpText<"Emit Flang LLVM files for source inputs">;
 def emit_llvm : Flag<["-"], "emit-llvm">, Flags<[CC1Option]>, Group<Action_Group>,
   HelpText<"Use the LLVM representation for assembler and object files">;
 def emit_interface_stubs : Flag<["-"], "emit-interface-stubs">, Flags<[CC1Option]>, Group<Action_Group>,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -288,6 +288,9 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
   } else if ((PhaseArg = DAL.getLastArg(options::OPT_fsyntax_only)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_print_supported_cpus)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_module_file_info)) ||
+#ifdef ENABLE_CLASSIC_FLANG
+             (PhaseArg = DAL.getLastArg(options::OPT_emit_flang_llvm)) ||
+#endif
              (PhaseArg = DAL.getLastArg(options::OPT_verify_pch)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_rewrite_objc)) ||
              (PhaseArg = DAL.getLastArg(options::OPT_rewrite_legacy_objc)) ||

--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -86,6 +86,11 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
     llvm::sys::path::replace_extension(Stem, "");
   }
 
+  if (Args.hasArg(options::OPT_emit_flang_llvm)) {
+    // -emit-flang-llvm only supports asm output so claim -S to prevent warning
+    Args.ClaimAllArgs(options::OPT_S);
+  }
+
   // Add input file name to the compilation line
   UpperCmdArgs.push_back(Input.getBaseInput());
 

--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -402,6 +402,9 @@ types::getCompilationPhases(const clang::driver::Driver &Driver,
   else if (DAL.getLastArg(options::OPT_fsyntax_only) ||
            DAL.getLastArg(options::OPT_print_supported_cpus) ||
            DAL.getLastArg(options::OPT_module_file_info) ||
+#ifdef ENABLE_CLASSIC_FLANG
+           DAL.getLastArg(options::OPT_emit_flang_llvm) ||
+#endif
            DAL.getLastArg(options::OPT_verify_pch) ||
            DAL.getLastArg(options::OPT_rewrite_objc) ||
            DAL.getLastArg(options::OPT_rewrite_legacy_objc) ||

--- a/clang/test/Driver/flang/classic-flang-emit-flang-llvm.f95
+++ b/clang/test/Driver/flang/classic-flang-emit-flang-llvm.f95
@@ -1,0 +1,10 @@
+! REQUIRES: classic_flang
+
+! Check that the -emit-flang-llvm option dumps LLVM IR pre-optimisation
+
+! RUN: %clang --driver-mode=flang -emit-flang-llvm -S -o %t.ll %s -### 2>&1 \
+! RUN:   | FileCheck %s
+! CHECK-NOT: argument unused during compilation: '-S'
+! CHECK: "{{.*}}flang1"
+! CHECK-NEXT: "{{.*}}flang2"
+! CHECK-NOT: "{{.*}}clang{{.*}}" "-cc1"


### PR DESCRIPTION
-emit-flang-llvm instructs flang to stop after flang2 and dump the LLVM IR.

Can be useful for debugging and also would be a useful option for testing flang
output more accurately.

Signed-off-by: Richard Barton <richard.barton@arm.com>