### PR TITLE
Introduce handling of the -dM option into flang

### DIFF
--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -132,6 +132,11 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("-nosave");
   }
 
+  for (auto Arg : Args.filtered(options::OPT_dM)) {
+    Arg->claim();
+    UpperCmdArgs.push_back("-list-macros");
+  }
+
   // Treat denormalized numbers as zero: On
   for (auto Arg : Args.filtered(options::OPT_Mdaz_on)) {
     Arg->claim();

--- a/clang/test/Driver/flang/list-macros.f95
+++ b/clang/test/Driver/flang/list-macros.f95
@@ -1,0 +1,8 @@
+! REQUIRES: classic_flang
+
+! Check that the driver invokes flang1 correctly when flang invokes with -dM option
+
+! RUN: %clang --driver-mode=flang -dM -target x86_64-unknown-linux-gnu -c %s -### 2>&1 \
+! RUN:   | FileCheck %s
+! CHECK: "{{.*}}flang1"
+! CHECK: "-list-macros"


### PR DESCRIPTION
It was decided to add clang -dM option to flang.
It prints out all the macros defined - similarly as clang or gfortran does it.
It works only with flang PR for this: https://github.com/flang-compiler/flang/pull/1223