### PR TITLE
Allow /dev/null to be an input file.

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2187,7 +2187,14 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
           if (!Args.hasArgNoClaim(options::OPT_E) && !CCCIsCPP())
             Diag(IsCLMode() ? clang::diag::err_drv_unknown_stdin_type_clang_cl
                             : clang::diag::err_drv_unknown_stdin_type);
-          Ty = types::TY_C;
+          if (IsFlangMode()) { 
+#ifdef ENABLE_CLASSIC_FLANG
+            Ty = types::TY_PP_F_FreeForm; 
+#else
+            Ty = types::TY_PP_Fortran;
+#endif
+          } else
+            Ty = types::TY_C;
         } else {
           // Otherwise lookup by extension.
           // Fallback is C if invoked as C preprocessor, C++ if invoked with

--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -82,12 +82,23 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
     Stem = C.getDriver().GetTemporaryPath("", "");
   } else {
     OutFile = Output.getFilename();
+    if (OutFile == "-.ll")
+      OutFile = "tmp";
     Stem = llvm::sys::path::filename(OutFile);
     llvm::sys::path::replace_extension(Stem, "");
   }
 
   // Add input file name to the compilation line
-  UpperCmdArgs.push_back(Input.getBaseInput());
+  const char *InputFile = Input.getBaseInput();
+  if (strcmp(InputFile, "-") == 0)
+  // FIXME: done specially for handling flang -E -dM - < /dev/null
+#if defined(_WIN32) || defined(_WIN64)
+    UpperCmdArgs.push_back("nul");
+#else
+    UpperCmdArgs.push_back("/dev/stdin");
+#endif
+  else
+    UpperCmdArgs.push_back(Input.getBaseInput());
 
   // Add temporary output for ILM
   const char * ILMFile = Args.MakeArgString(Stem + ".ilm");

--- a/clang/test/Driver/flang/dev_null_as_input_linux.f95
+++ b/clang/test/Driver/flang/dev_null_as_input_linux.f95
@@ -1,0 +1,11 @@
+! REQUIRES: classic_flang
+! REQUIRES: system-linux
+
+! Check that the driver invokes flang1 correctly for preprocessed fixed-form
+! Fortran code.
+
+! RUN: %clang --driver-mode=flang -E -target x86_64-unknown-linux-gnu -c - </dev/null -### 2>&1 \
+! RUN:   | FileCheck %s
+! CHECK: "{{.*}}flang1"
+! CHECK: "/dev/stdin"
+! CHECK: "tmp.ilm"

--- a/clang/test/Driver/flang/dev_null_as_input_windows.f95
+++ b/clang/test/Driver/flang/dev_null_as_input_windows.f95
@@ -1,0 +1,11 @@
+! REQUIRES: classic_flang
+! REQUIRES: system-windows
+
+! Check that the driver invokes flang1 correctly for preprocessed fixed-form
+! Fortran code.
+
+! RUN: %clang --driver-mode=flang -E -target x86_64-unknown-windows-gnu -c - < NUL -### 2>&1 \
+! RUN:   | FileCheck %s
+! CHECK: "{{.*}}flang1"
+! CHECK: "nul"
+! CHECK: "tmp.ilm"


### PR DESCRIPTION
This is patch for following problem:
`Problem is in flang that when -</dev/null is putted as an input file, then the clang is invoked instead of flang1.
We can see this via invoking example command:
flang -### -E -</dev/null
Then the clang is raised in first order.
We would like to to behave similar as we would invoke:
flang -### -E <input_file.f90>
In this scenario we can see that flang1 is raised in first order`

Make fortran mode when an input is '-' character indicating stdin.
Make temporary file and make /dev/stdin an input to flang1.
Test file for this change also is added

@bryanpkc @kiranchandramohan @michalpasztamobica @pawosm-arm @RichBarton-Arm @shivaramaarao Please take a look on the patch.Thanks