### PR TITLE
Back-port some upstream fixes for macOS test failures

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -114,6 +114,8 @@ ld64_cmd = config.ld64_executable
 asan_rtlib = get_asan_rtlib()
 if asan_rtlib:
     ld64_cmd = 'DYLD_INSERT_LIBRARIES={} {}'.format(asan_rtlib, ld64_cmd)
+if config.osx_sysroot:
+    ld64_cmd = '{} -syslibroot {}'.format(ld64_cmd, config.osx_sysroot)
 
 ocamlc_command = '%s ocamlc -cclib -L%s %s' % (
     config.ocamlfind_executable, config.llvm_lib_dir, config.ocaml_flags)

--- a/llvm/test/lit.site.cfg.py.in
+++ b/llvm/test/lit.site.cfg.py.in
@@ -15,6 +15,7 @@ config.lit_tools_dir = path(r"@LLVM_LIT_TOOLS_DIR@")
 config.python_executable = "@Python3_EXECUTABLE@"
 config.gold_executable = "@GOLD_EXECUTABLE@"
 config.ld64_executable = "@LD64_EXECUTABLE@"
+config.osx_sysroot = "@CMAKE_OSX_SYSROOT@"
 config.ocamlfind_executable = "@OCAMLFIND@"
 config.have_ocamlopt = @HAVE_OCAMLOPT@
 config.have_ocaml_ounit = @HAVE_OCAML_OUNIT@

--- a/llvm/test/tools/lto/hide-linkonce-odr.ll
+++ b/llvm/test/tools/lto/hide-linkonce-odr.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macosx_version_min 10.10.0 -lSystem -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _c -exported_symbol _b  -exported_symbol _GlobLinkonce
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -dylib -arch x86_64 -macosx_version_min 10.10.0 -o %t.dylib %t.o -save-temps  -undefined dynamic_lookup -exported_symbol _c -exported_symbol _b  -exported_symbol _GlobLinkonce -lSystem
 
 ; RUN: llvm-dis %t.dylib.lto.opt.bc -o - | FileCheck --check-prefix=IR %s
 ; check that @a is no longer a linkonce_odr definition

--- a/llvm/test/tools/lto/no-bitcode.s
+++ b/llvm/test/tools/lto/no-bitcode.s
@@ -2,4 +2,4 @@
 ; libLTO.dylib shouldn't assert on invalid inputs.
 ; RUN: llvm-mc -triple=arm64-apple-ios7.0.0 -filetype=obj -o %t.o
 ; RUN: llvm-ar r %t.a %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -O0 -o %t.dylib %t.a
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -O0 -o %t.dylib %t.a -lSystem

--- a/llvm/test/tools/lto/opt-level.ll
+++ b/llvm/test/tools/lto/opt-level.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -O0 -o %t.dylib %t.o
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -O0 -o %t.dylib %t.o -lSystem
 ; RUN: llvm-nm --no-llvm-bc %t.dylib | FileCheck --check-prefix=CHECK-O0 %s
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -O2 -o %t.dylib %t.o
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -O2 -o %t.dylib %t.o -lSystem
 ; RUN: llvm-nm --no-llvm-bc %t.dylib | FileCheck --check-prefix=CHECK-O2 %s
 
 target triple = "x86_64-apple-macosx10.8.0"

--- a/llvm/test/tools/lto/print-stats.ll
+++ b/llvm/test/tools/lto/print-stats.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -stats -o %t.dylib %t.o 2>&1 | FileCheck --check-prefix=STATS %s
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -o %t.dylib %t.o 2>&1 | FileCheck --check-prefix=NO_STATS %s
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -stats -o %t.dylib %t.o -lSystem 2>&1 | FileCheck --check-prefix=STATS %s
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -o %t.dylib %t.o -lSystem 2>&1 | FileCheck --check-prefix=NO_STATS %s
 ; REQUIRES: asserts
 
 target triple = "x86_64-apple-macosx10.8.0"

--- a/llvm/unittests/ADT/TripleTest.cpp
+++ b/llvm/unittests/ADT/TripleTest.cpp
@@ -1261,6 +1261,14 @@ TEST(TripleTest, getOSVersion) {
   EXPECT_EQ((unsigned)0, Minor);
   EXPECT_EQ((unsigned)0, Micro);
 
+  // For darwin triples on macOS 11, only compare the major version.
+  T = Triple("x86_64-apple-darwin20.2");
+  EXPECT_TRUE(T.isMacOSX());
+  T.getMacOSXVersion(Major, Minor, Micro);
+  EXPECT_EQ((unsigned)11, Major);
+  EXPECT_EQ((unsigned)0, Minor);
+  EXPECT_EQ((unsigned)0, Micro);
+
   T = Triple("armv7-apple-ios");
   EXPECT_FALSE(T.isMacOSX());
   EXPECT_TRUE(T.isiOS());

--- a/llvm/unittests/Support/Host.cpp
+++ b/llvm/unittests/Support/Host.cpp
@@ -347,9 +347,15 @@ TEST_F(HostTest, getMacOSHostVersion) {
   unsigned HostMajor, HostMinor, HostMicro;
   ASSERT_EQ(HostTriple.getMacOSXVersion(HostMajor, HostMinor, HostMicro), true);
 
-  // Don't compare the 'Micro' version, as it's always '0' for the 'Darwin'
-  // triples.
-  ASSERT_EQ(std::tie(SystemMajor, SystemMinor), std::tie(HostMajor, HostMinor));
+  if (SystemMajor > 10) {
+    // Don't compare the 'Minor' and 'Micro' versions, as they're always '0' for
+    // the 'Darwin' triples on 11.x.
+    ASSERT_EQ(SystemMajor, HostMajor);
+  } else {
+    // Don't compare the 'Micro' version, as it's always '0' for the 'Darwin'
+    // triples.
+    ASSERT_EQ(std::tie(SystemMajor, SystemMinor), std::tie(HostMajor, HostMinor));
+  }
 }
 #endif
 


### PR DESCRIPTION
This PR back-ports two upstream commits (c747b7d1d9a2 and a1265690cf614) to `release_11x`, to resolve some CI failures on MacOS.
```
commit c747b7d1d9a2c9e4ba82ce93c9273c1662d6994a
Author: Steven Wu <stevenwu@apple.com>
Date:   Tue Jun 22 09:21:12 2021 -0700

    [llvm] Fix lto tests that requires ld64

    Since Xcode 13, ld64 requires linking libSystem for all the executable.
    Fix the tests that needs to run ld64 by linking libSystem from sysroot.

    rdar://77332728

    Reviewed By: fhahn

    Differential Revision: https://reviews.llvm.org/D104332

commit a1265690cf614bde8a7fd1d503c5f13c184dc786
Author: Amara Emerson <amara@apple.com>
Date:   Wed Jan 6 14:40:17 2021 -0800

    Fix failing triple test for macOS 11 with non-zero minor versions.

    Differential Revision: https://reviews.llvm.org/D94197
```