### PR TITLE
Fix classic flang version screen

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1630,7 +1630,11 @@ void Driver::PrintHelp(bool ShowHidden) const {
 
 void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   if (IsFlangMode()) {
+#ifdef ENABLE_CLASSIC_FLANG
+    OS << getClangToolFullVersion("flang") << '\n';
+#else
     OS << getClangToolFullVersion("flang-new") << '\n';
+#endif
   } else {
     // FIXME: The following handlers should use a callback mechanism, we don't
     // know what the client would like to do.

--- a/clang/test/Driver/flang/classic-flang-version.f
+++ b/clang/test/Driver/flang/classic-flang-version.f
@@ -1,0 +1,3 @@
+! REQUIRES: classic-flang
+! RUN: %flang --version | FileCheck %s
+! CHECK: flang version {{.*}} ({{.*}}flang-compiler/classic-flang-llvm-project.git {{.*}})


### PR DESCRIPTION
Version screen has been erroneously reporting as flang-new since LLVM 12