### PR TITLE
Fix flang driver preprocessor issue

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -331,14 +331,7 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
       (PhaseArg = DAL.getLastArg(options::OPT_M, options::OPT_MM)) ||
       (PhaseArg = DAL.getLastArg(options::OPT__SLASH_P)) ||
       CCGenDiagnostics) {
-#ifdef ENABLE_CLASSIC_FLANG
-    if (IsFlangMode())
-      FinalPhase = phases::Compile;
-    else
-      FinalPhase = phases::Preprocess;
-#else
     FinalPhase = phases::Preprocess;
-#endif
 
   // --precompile only runs up to precompilation.
   } else if ((PhaseArg = DAL.getLastArg(options::OPT__precompile))) {
@@ -2337,7 +2330,11 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
         if (memcmp(Value, "-", 2) == 0) {
           if (IsFlangMode()) {
 #ifdef ENABLE_CLASSIC_FLANG
-            Ty = types::TY_C;
+          // If running with -E, treat as needing preprocessing
+          if (!Args.hasArgNoClaim(options::OPT_E))
+            Ty = types::TY_PP_F_FreeForm;
+          else
+            Ty = types::TY_F_FreeForm;
 #else
             Ty = types::TY_Fortran;
 #endif
@@ -2362,6 +2359,16 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
           // idea of what .s is.
           if (const char *Ext = strrchr(Value, '.'))
             Ty = TC.LookupTypeForExtension(Ext + 1);
+#ifdef ENABLE_CLASSIC_FLANG
+            // If called with -E, treat the inputs as needing preprocessing
+            // regardless of extension
+            if (IsFlangMode() && Args.hasArgNoClaim(options::OPT_E)) {
+              if (Ty == types::TY_PP_F_FreeForm)
+                Ty = types::TY_F_FreeForm;
+              else if (Ty == types::TY_PP_F_FixedForm)
+                Ty = types::TY_F_FixedForm;
+            }
+#endif
 
           if (Ty == types::TY_INVALID) {
             if (IsCLMode() && (Args.hasArgNoClaim(options::OPT_E) || CCGenDiagnostics))

--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -79,8 +79,8 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
   // Check file type sanity
   assert(types::isFortran(InputType) && "Can only accept Fortran");
 
-  if (Args.hasArg(options::OPT_fsyntax_only)) {
-    // For -fsyntax-only produce temp files only
+  if (Args.hasArg(options::OPT_fsyntax_only, options::OPT_E)) {
+    // For -fsyntax-only and -E produce temp files only
     Stem = C.getDriver().GetTemporaryPath("", "");
   } else {
     OutFile = Output.getFilename();

--- a/clang/test/Driver/fortran-phases.f90
+++ b/clang/test/Driver/fortran-phases.f90
@@ -7,6 +7,7 @@
 ! RUN: %flang -ccc-print-phases -S 2>&1 %s | FileCheck %s --check-prefix=AONLY-NOPP
 ! RUN: %flang -ccc-print-phases -c -emit-llvm 2>&1 %s | FileCheck %s --check-prefix=LLONLY-NOPP
 ! RUN: %flang -ccc-print-phases -S -emit-llvm 2>&1 %s | FileCheck %s --check-prefix=LLONLY-NOPP
+! RUN: %flang -ccc-print-phases -emit-flang-llvm 2>&1 %s | FileCheck %s --check-prefix=FLLONLY-NOPP
 ! RUN: %flang -ccc-print-phases -fsyntax-only 2>&1 %s | FileCheck %s --check-prefix=SONLY-NOPP
 ! RUN: %flang -ccc-print-phases -E 2>&1 %s | FileCheck %s --check-prefix=PPONLY-NOPP
 
@@ -16,6 +17,7 @@
 ! RUN: %flang -ccc-print-phases -S 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=AONLY
 ! RUN: %flang -ccc-print-phases -c -emit-llvm 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=LLONLY
 ! RUN: %flang -ccc-print-phases -S -emit-llvm 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=LLONLY
+! RUN: %flang -ccc-print-phases -emit-flang-llvm 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=FLLONLY
 ! RUN: %flang -ccc-print-phases -fsyntax-only 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=SONLY
 ! RUN: %flang -ccc-print-phases -E 2>&1 -x f95-cpp-input %s | FileCheck %s --check-prefix=PPONLY
 
@@ -29,31 +31,39 @@
 ! CONLY-NOPP: 1: compiler, {0}, ir
 ! CONLY-NOPP: 2: backend, {1}, assembler
 ! CONLY-NOPP: 3: assembler, {2}, object
-! CONLY-NOPP-NOT: 4: linker, {3}, image
+! CONLY-NOPP-NOT: {{.*}}: linker, {{{.*}}}, image
 
 ! AONLY-NOPP: 0: input, {{.*}}, f95
 ! AONLY-NOPP: 1: compiler, {0}, ir
 ! AONLY-NOPP: 2: backend, {1}, assembler
-! AONLY-NOPP-NOT: 3: assembler, {2}, object
-! AONLY-NOPP-NOT: 4: linker, {3}, image
+! AONLY-NOPP-NOT: {{.*}}: assembler, {{{.*}}}, object
+! AONLY-NOPP-NOT: {{.*}}: linker, {{{.*}}}, image
 
 ! LLONLY-NOPP: 0: input, {{.*}}, f95
 ! LLONLY-NOPP: 1: compiler, {0}, ir
-! LLONLY-NOPP-NOT: 2: backend, {1}, assembler
-! LLONLY-NOPP-NOT: 3: assembler, {2}, object
-! LLONLY-NOPP-NOT: 4: linker, {3}, image
+! LLONLY-NOPP-NOT: {{.*}}: backend, {{{.*}}}, assembler
+! LLONLY-NOPP-NOT: {{.*}}: assembler, {{{.*}}}, object
+! LLONLY-NOPP-NOT: {{.*}}: linker, {{{.*}}}, image
+
+! FLLONLY-NOPP: 0: input, {{.*}}, f95
+! FLLONLY-NOPP: 1: compiler, {0}, ir
+! FLLONLY-NOPP-NOT: {{.*}}: backend, {{{.*}}}, assembler
+! FLLONLY-NOPP-NOT: {{.*}}: assembler, {{{.*}}}, object
+! FLLONLY-NOPP-NOT: {{.*}}: linker, {{{.*}}}, image
 
 ! SONLY-NOPP: 0: input, {{.*}}, f95
-! SONLY-NOPP-NOT: 1: compiler, {0}, ir
-! SONLY-NOPP-NOT: 2: backend, {1}, assembler
-! SONLY-NOPP-NOT: 3: assembler, {2}, object
-! SONLY-NOPP-NOT: 4: linker, {3}, image
+! SONLY-NOPP-NOT: {{.*}}: compiler, {{{.*}}}, ir
+! SONLY-NOPP-NOT: {{.*}}: backend, {{{.*}}}, assembler
+! SONLY-NOPP-NOT: {{.*}}: assembler, {{{.*}}}, object
+! SONLY-NOPP-NOT: {{.*}}: linker, {{{.*}}}, image
 
+! flang always preprocesses with -E regardless of file extension
 ! PPONLY-NOPP: 0: input, {{.*}}, f95
-! PPONLY-NOPP: 1: compiler, {0}, ir
-! PPONLY-NOPP-NOT: 2: backend, {1}, assembler
-! PPONLY-NOPP-NOT: 3: assembler, {2}, object
-! PPONLY-NOPP-NOT: 4: linker, {3}, image
+! PPONLY-NOPP: 1: preprocessor, {0}, f95
+! PPONLY-NOPP-NOT: {{.*}}: compiler, {{{.*}}}, ir
+! PPONLY-NOPP-NOT: {{.*}}: backend, {{{.*}}}, assembler
+! PPONLY-NOPP-NOT: {{.*}}: assembler, {{{.*}}}, object
+! PPONLY-NOPP-NOT: {{.*}}: linker, {{{.*}}}, image
 
 ! LINK: 0: input, {{.*}}, f95-cpp-input
 ! LINK: 1: preprocessor, {0}, f95
@@ -67,35 +77,42 @@
 ! CONLY: 2: compiler, {1}, ir
 ! CONLY: 3: backend, {2}, assembler
 ! CONLY: 4: assembler, {3}, object
-! CONLY-NOT: 5: linker, {4}, image
+! CONLY-NOT: {{.*}}: linker, {{{.*}}}, image
 
 ! AONLY: 0: input, {{.*}}, f95-cpp-input
 ! AONLY: 1: preprocessor, {0}, f95
 ! AONLY: 2: compiler, {1}, ir
 ! AONLY: 3: backend, {2}, assembler
-! AONLY-NOT: 4: assembler, {3}, object
-! AONLY-NOT: 5: linker, {4}, image
+! AONLY-NOT: {{.*}}: assembler, {{{.*}}}, object
+! AONLY-NOT: {{.*}}: linker, {{{.*}}}, image
 
 ! LLONLY: 0: input, {{.*}}, f95-cpp-input
 ! LLONLY: 1: preprocessor, {0}, f95
 ! LLONLY: 2: compiler, {1}, ir
-! LLONLY-NOT: 3: backend, {2}, assembler
-! LLONLY-NOT: 4: assembler, {3}, object
-! LLONLY-NOT: 5: linker, {4}, image
+! LLONLY-NOT: {{.*}}: backend, {{{.*}}}, assembler
+! LLONLY-NOT: {{.*}}: assembler, {{{.*}}}, object
+! LLONLY-NOT: {{.*}}: linker, {{{.*}}}, image
+
+! FLLONLY: 0: input, {{.*}}, f95-cpp-input
+! FLLONLY: 1: preprocessor, {0}, f95
+! FLLONLY: 2: compiler, {1}, ir
+! FLLONLY-NOT: {{.*}}: backend, {{{.*}}}, assembler
+! FLLONLY-NOT: {{.*}}: assembler, {{{.*}}}, object
+! FLLONLY-NOT: {{.*}}: linker, {{{.*}}}, image
 
 ! SONLY: 0: input, {{.*}}, f95-cpp-input
 ! SONLY: 1: preprocessor, {0}, f95
-! SONLY-NOT: 2: compiler, {1}, ir
-! SONLY-NOT: 3: backend, {2}, assembler
-! SONLY-NOT: 4: assembler, {3}, object
-! SONLY-NOT: 5: linker, {4}, image
+! SONLY-NOT: {{.*}}: compiler, {{{.*}}}, ir
+! SONLY-NOT: {{.*}}: backend, {{{.*}}}, assembler
+! SONLY-NOT: {{.*}}: assembler, {{{.*}}}, object
+! SONLY-NOT: {{.*}}: linker, {{{.*}}}, image
 
 ! PPONLY: 0: input, {{.*}}, f95-cpp-input
 ! PPONLY: 1: preprocessor, {0}, f95
-! PPONLY: 2: compiler, {1}, ir
-! PPONLY-NOT: 3: backend, {2}, assembler
-! PPONLY-NOT: 4: assembler, {3}, object
-! PPONLY-NOT: 5: linker, {4}, image
+! PPONLY-NOT: {{.*}}: compiler, {{{.*}}}, ir
+! PPONLY-NOT: {{.*}}: backend, {{{.*}}}, assembler
+! PPONLY-NOT: {{.*}}: assembler, {{{.*}}}, object
+! PPONLY-NOT: {{.*}}: linker, {{{.*}}}, image
 
 program hello
   write(*, *) "Hello"

--- a/clang/test/Driver/fortran-preprocessor.f90
+++ b/clang/test/Driver/fortran-preprocessor.f90
@@ -1,0 +1,47 @@
+! REQUIRES: classic_flang
+
+! -cpp should preprocess as it goes, regardless of input file extension
+! RUN: %flang -cpp -c -DHELLO="hello all" -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP,PP
+! RUN: %flang -cpp -c -DHELLO="hello all" -### -c f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP,PP
+! -E should preprocess then stop, regardless of input file extension
+! RUN: %flang -E -DHELLO="hello all" -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
+! RUN: %flang -E -DHELLO="hello all" -### -x f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
+! -cpp and -E are redundant
+! RUN: %flang -E -cpp -DHELLO="hello all" -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
+
+! Don't link when given linker input
+! RUN: %flang -E -cpp -Wl,-rpath=blah -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
+
+! Explicitly test this nonsence case causing a bug with LLVM 13/14
+! RUN: %flang -E -traditional-cpp -DHELLO="hello all" -x f95-cpp-input -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
+
+! Test -save-temps does not break things (same codepath as -traditional-cpp bug above)
+! RUN: %flang -E -DHELLO="hello all" -save-temps -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
+! RUN: %flang -E -DHELLO="hello all" -save-temps -### -c f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
+! RUN: %flang -cpp -c -DHELLO="hello all" -save-temps -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP
+! RUN: %flang -cpp -c -DHELLO="hello all" -save-temps -### -c f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP
+
+! Test for the correct cmdline flags
+! Consume up to flang1 line
+! ALL-LABEL: "{{.*}}flang1"
+! CPP-NOT: "-es"
+! CPP: "-preprocess"
+! CPP-NOT: "-es"
+
+! E-DAG: "-es"
+! E-DAG: "-preprocess"
+
+! flang1 should only be called once!
+! ALL-NOT: "{{.*}}flang1"
+
+! CPP should continue to build object
+! PP: "{{.*}}flang2"
+! PPONLY-NOT: "{{.*}}flang2"
+
+! These commands should never call a linker!
+! ALL-NOT: "{{.*}}ld"
+
+program hello
+  write(*, *) HELLO
+end program hello
+


### PR DESCRIPTION
Fix a bug where flang -E -save-temps input.F90 would preprocess
the input file twice. Add a new test for preprocessor behaviour that
would expose the bug and updated fortran-phases test for new behaviour.

Also added -emit-flang-llvm to that test for completeness.

Signed-off-by: Richard Barton <richard.barton@arm.com>