### PR TITLE
[DebugInfo] Reduce downstream delta in DIGlobalVariable

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -568,7 +568,7 @@ endif(LLVM_BUILD_EXAMPLES)
 option(LLVM_BUILD_TESTS
   "Build LLVM unit tests. If OFF, just generate build targets." OFF)
 option(LLVM_INCLUDE_TESTS "Generate build targets for the LLVM unit tests." ON)
-option(LLVM_INCLUDE_GO_TESTS "Include the Go bindings tests in test build targets." ON)
+option(LLVM_INCLUDE_GO_TESTS "Include the Go bindings tests in test build targets." OFF)
 
 option(LLVM_BUILD_BENCHMARKS "Add LLVM benchmark targets to the list of default
 targets. If OFF, benchmarks still could be built using Benchmarks target." OFF)

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4955,21 +4955,6 @@ bool LLParser::parseDITemplateValueParameter(MDNode *&Result, bool IsDistinct) {
 ///                         isDefinition: true, templateParams: !3,
 ///                         declaration: !4, align: 8)
 bool LLParser::parseDIGlobalVariable(MDNode *&Result, bool IsDistinct) {
-#ifdef ENABLE_CLASSIC_FLANG
-#define VISIT_MD_FIELDS(OPTIONAL, REQUIRED)                                    \
-  OPTIONAL(name, MDStringField, (/* AllowEmpty */ true));                      \
-  OPTIONAL(scope, MDField, );                                                  \
-  OPTIONAL(linkageName, MDStringField, );                                      \
-  OPTIONAL(file, MDField, );                                                   \
-  OPTIONAL(line, LineField, );                                                 \
-  OPTIONAL(type, MDField, );                                                   \
-  OPTIONAL(isLocal, MDBoolField, );                                            \
-  OPTIONAL(isDefinition, MDBoolField, (true));                                 \
-  OPTIONAL(templateParams, MDField, );                                         \
-  OPTIONAL(declaration, MDField, );                                            \
-  OPTIONAL(flags, DIFlagField, );                                              \
-  OPTIONAL(align, MDUnsignedField, (0, UINT32_MAX));
-#else
 #define VISIT_MD_FIELDS(OPTIONAL, REQUIRED)                                    \
   REQUIRED(name, MDStringField, (/* AllowEmpty */ false));                     \
   OPTIONAL(scope, MDField, );                                                  \
@@ -4983,7 +4968,6 @@ bool LLParser::parseDIGlobalVariable(MDNode *&Result, bool IsDistinct) {
   OPTIONAL(declaration, MDField, );                                            \
   OPTIONAL(flags, DIFlagField, );                                              \
   OPTIONAL(align, MDUnsignedField, (0, UINT32_MAX));
-#endif
   PARSE_MD_FIELDS();
 #undef VISIT_MD_FIELDS
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4956,7 +4956,7 @@ bool LLParser::parseDITemplateValueParameter(MDNode *&Result, bool IsDistinct) {
 ///                         declaration: !4, align: 8)
 bool LLParser::parseDIGlobalVariable(MDNode *&Result, bool IsDistinct) {
 #define VISIT_MD_FIELDS(OPTIONAL, REQUIRED)                                    \
-  REQUIRED(name, MDStringField, (/* AllowEmpty */ false));                     \
+  OPTIONAL(name, MDStringField, (/* AllowEmpty */ false));                     \
   OPTIONAL(scope, MDField, );                                                  \
   OPTIONAL(linkageName, MDStringField, );                                      \
   OPTIONAL(file, MDField, );                                                   \

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -166,8 +166,7 @@ DIE *DwarfCompileUnit::getOrCreateGlobalVariableDIE(
   } else {
     DeclContext = GV->getScope();
     // Add name and type.
-    if (!GV->getDisplayName().empty())
-      addString(*VariableDIE, dwarf::DW_AT_name, GV->getDisplayName());
+    addString(*VariableDIE, dwarf::DW_AT_name, GV->getDisplayName());
     if (GTy)
       addType(*VariableDIE, GTy);
 

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -1394,8 +1394,6 @@ void Verifier::visitDIGlobalVariable(const DIGlobalVariable &N) {
   visitDIVariable(N);
 
   AssertDI(N.getTag() == dwarf::DW_TAG_variable, "invalid tag", &N);
-  AssertDI(!N.getName().empty() || N.isArtificial(),
-           "missing global variable name", &N);
   AssertDI(isType(N.getRawType()), "invalid type ref", &N, N.getRawType());
   // Assert only if the global variable is not an extern
   if (N.isDefinition())

--- a/llvm/test/Assembler/invalid-diglobalvariable-empty-name.ll
+++ b/llvm/test/Assembler/invalid-diglobalvariable-empty-name.ll
@@ -1,5 +1,4 @@
 ; RUN: not llvm-as < %s -disable-output 2>&1 | FileCheck %s
-; UNSUPPORTED: classic_flang
 
 ; CHECK: <stdin>:[[@LINE+1]]:30: error: 'name' cannot be empty
 !0 = !DIGlobalVariable(name: "")

--- a/llvm/test/Assembler/invalid-diglobalvariable-missing-name.ll
+++ b/llvm/test/Assembler/invalid-diglobalvariable-missing-name.ll
@@ -1,4 +1,0 @@
-; RUN: not llvm-as < %s -disable-output 2>&1 | FileCheck %s
-
-; CHECK: <stdin>:[[@LINE+1]]:24: error: missing required field 'name'
-!0 = !DIGlobalVariable()

--- a/llvm/test/Assembler/invalid-diglobalvariable-missing-name.ll
+++ b/llvm/test/Assembler/invalid-diglobalvariable-missing-name.ll
@@ -1,5 +1,4 @@
 ; RUN: not llvm-as < %s -disable-output 2>&1 | FileCheck %s
-; UNSUPPORTED: classic_flang
 
 ; CHECK: <stdin>:[[@LINE+1]]:24: error: missing required field 'name'
 !0 = !DIGlobalVariable()


### PR DESCRIPTION
Now that https://github.com/flang-compiler/flang/commit/65d1e98 has been merged, we can revert the changes introduced in the following commits:

- https://github.com/flang-compiler/llvm/commit/5c217c2
- https://github.com/flang-compiler/llvm/commit/e35c28b
- https://github.com/flang-compiler/llvm/commit/04e9699

See https://github.com/flang-compiler/classic-flang-llvm-project/issues/2 for information.

This also fixes an assertion failure in `llvm/lib/IR/Verifier.cpp` when compiling the following test case with `clang++ -c -std=c++17 -g test.cpp` (from https://github.com/llvm/llvm-project/issues/55376):
```c
#include <initializer_list>
#include <type_traits>
#include <utility>

int arr[2] = {1, 2};
std::pair<int, int> pr = {1, 2};

auto f1() -> int (&)[2] { return arr; }

auto f2() -> std::pair<int, int> & { return pr; }

struct S {
  int x1 : 2;
  volatile double y1;
};

S f3() { return {}; }

auto [x1, y1] = f1();
auto &[xr1, yr1] = f1();
auto [x2, y2] = f2();
auto &[xr2, yr2] = f2();
const auto [x3, y3] = f3();
```