### PR TITLE
Changes to flang's fp-contract behaviour (release_13x)

### DIFF
--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -462,28 +462,6 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
-  // Enable FMA
-  for (Arg *A: Args.filtered(options::OPT_Mfma_on, options::OPT_fma)) {
-    A->claim();
-    LowerCmdArgs.push_back("-x");
-    LowerCmdArgs.push_back("172");
-    LowerCmdArgs.push_back("0x40000000");
-    LowerCmdArgs.push_back("-x");
-    LowerCmdArgs.push_back("179");
-    LowerCmdArgs.push_back("1");
-  }
-
-  // Disable FMA
-  for (Arg *A: Args.filtered(options::OPT_Mfma_off, options::OPT_nofma)) {
-    A->claim();
-    LowerCmdArgs.push_back("-x");
-    LowerCmdArgs.push_back("171");
-    LowerCmdArgs.push_back("0x40000000");
-    LowerCmdArgs.push_back("-x");
-    LowerCmdArgs.push_back("178");
-    LowerCmdArgs.push_back("1");
-  }
-
   // For -fPIC set -x 62 8 for second part of Fortran frontend
   for (Arg *A: Args.filtered(options::OPT_fPIC)) {
     A->claim();
@@ -546,6 +524,59 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
       NeedIEEE = false;
     }
     A->claim();
+  }
+
+  // fp-contract=fast is the default
+  bool EnableFPContraction = true;
+  if (Arg *A = Args.getLastArg(options::OPT_ffp_contract,
+                             options::OPT_Mfma_on,
+                             options::OPT_fma,
+                             options::OPT_Mfma_off,
+                             options::OPT_nofma)) {
+    auto Opt = A->getOption();
+    if (Opt.matches(options::OPT_ffp_contract)) {
+      StringRef Val = A->getValue();
+      if ((Val == "fast") || (Val == "on")) {
+        EnableFPContraction = true;
+      } else if (Val == "off") {
+        EnableFPContraction = false;
+      } else {
+        D.Diag(diag::err_drv_unsupported_option_argument)
+          << A->getOption().getName() << Val;
+      }
+    } else if(Opt.matches(options::OPT_Mfma_on) ||
+              Opt.matches(options::OPT_fma)) {
+      EnableFPContraction = true;
+    } else {
+      EnableFPContraction = false;
+    }
+  }
+
+  if(OptLevel == 0)
+    EnableFPContraction = false;
+
+  // Emit contract math instructions.
+  // Step 1 : Generate fma instructions in flang (can override with fma flag)
+  // Step 2 : Propagate fma contract information to LLVM to further
+  //          exploit contraction opportunities
+  if (EnableFPContraction) {
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("172");
+    LowerCmdArgs.push_back("0x40000000");
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("179");
+    LowerCmdArgs.push_back("1");
+    // Step 2
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("216");
+    LowerCmdArgs.push_back("0x1000");
+  } else {
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("171");
+    LowerCmdArgs.push_back("0x40000000");
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("178");
+    LowerCmdArgs.push_back("1");
   }
 
   if (NeedFastMath) {

--- a/clang/test/Driver/flang/classic-flang-fp-contract.f95
+++ b/clang/test/Driver/flang/classic-flang-fp-contract.f95
@@ -1,0 +1,27 @@
+! REQUIRES: classic_flang
+
+! RUN: %flang -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT-ABSENCE
+! RUN: %flang -O1 -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -O2 -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -O3 -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -Ofast -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -ffp-contract=fast -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT-ABSENCE
+! RUN: %flang -O1 -ffp-contract=fast -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -O2 -ffp-contract=fast -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -O3 -ffp-contract=fast -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -Ofast -ffp-contract=fast -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -ffp-contract=on -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT-ABSENCE
+! RUN: %flang -O1 -ffp-contract=on -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -O2 -ffp-contract=on -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -O3 -ffp-contract=on -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -Ofast -ffp-contract=on -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT
+! RUN: %flang -ffp-contract=off -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT-ABSENCE
+! RUN: %flang -O1 -ffp-contract=off -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT-ABSENCE
+! RUN: %flang -O2 -ffp-contract=off -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT-ABSENCE
+! RUN: %flang -O3 -ffp-contract=off -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT-ABSENCE
+! RUN: %flang -Ofast -ffp-contract=off -c %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-FLANG2-FP-CONTRACT-ABSENCE
+
+! CHECK-FLANG2-FP-CONTRACT: "{{.*}}flang2"
+! CHECK-FLANG2-FP-CONTRACT-SAME: "-x" "172" "0x40000000" "-x" "179" "1" "-x" "216" "0x1000"
+! CHECK-FLANG2-FP-CONTRACT-ABSENCE: "{{.*}}flang2"
+! CHECK-FLANG2-FP-CONTRACT-ABSENCE-SAME: "-x" "171" "0x40000000" "-x" "178" "1"

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -568,7 +568,7 @@ endif(LLVM_BUILD_EXAMPLES)
 option(LLVM_BUILD_TESTS
   "Build LLVM unit tests. If OFF, just generate build targets." OFF)
 option(LLVM_INCLUDE_TESTS "Generate build targets for the LLVM unit tests." ON)
-option(LLVM_INCLUDE_GO_TESTS "Include the Go bindings tests in test build targets." ON)
+option(LLVM_INCLUDE_GO_TESTS "Include the Go bindings tests in test build targets." OFF)
 
 option(LLVM_BUILD_BENCHMARKS "Add LLVM benchmark targets to the list of default
 targets. If OFF, benchmarks still could be built using Benchmarks target." OFF)


### PR DESCRIPTION
1) All fma and contraction behvaviour follows from the -ffp-contract= flag
setting.
2) At optimization level 0, -ffp-contract=fast flag will not be honoured.
3) At all other levels, -ffp-contract=fast will be the default behaviour and
the flag is honoured.
This commit is accompanied with a symmetric change on the classic flang repository: https://github.com/flang-compiler/flang/pull/1267
