### PR TITLE
Changes for reassoc attributes (release_13x)

### DIFF
--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -69,6 +69,8 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
   bool NeedIEEE = true;
   bool NeedFastMath = false;
   bool NeedRelaxedMath = false;
+  bool AssociativeMath = false;
+  bool SignedZeros = true;
 
   // Check number of inputs for sanity. We need at least one input.
   assert(Inputs.size() >= 1 && "Must have at least one input.");
@@ -507,14 +509,18 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
   */
   for(Arg *A: Args.filtered(options::OPT_ffast_math, options::OPT_fno_fast_math,
                         options::OPT_Ofast, options::OPT_Kieee_off,
-                        options::OPT_Kieee_on, options::OPT_frelaxed_math)) {
+                        options::OPT_Kieee_on, options::OPT_frelaxed_math,
+                        options::OPT_fassociative_math,
+                        options::OPT_fno_associative_math,
+                        options::OPT_fsigned_zeros,
+                        options::OPT_fno_signed_zeros)) {
     if (A->getOption().matches(options::OPT_ffast_math) ||
         A->getOption().matches(options::OPT_Ofast)) {
       NeedIEEE = NeedRelaxedMath = false;
       NeedFastMath = true;
     } else if (A->getOption().matches(options::OPT_Kieee_on)) {
-      NeedFastMath = NeedRelaxedMath = false;
-      NeedIEEE = true;
+      NeedFastMath = NeedRelaxedMath = AssociativeMath = false;
+      NeedIEEE = SignedZeros = true;
     } else if (A->getOption().matches(options::OPT_frelaxed_math)) {
       NeedFastMath = NeedIEEE = false;
       NeedRelaxedMath = true;
@@ -522,6 +528,16 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
       NeedFastMath = false;
     } else if (A->getOption().matches(options::OPT_Kieee_off)) {
       NeedIEEE = false;
+    } else if (A->getOption().matches(options::OPT_fassociative_math)) {
+      AssociativeMath = true;
+      NeedIEEE = SignedZeros = false;
+    } else if (A->getOption().matches(options::OPT_fno_associative_math)) {
+      AssociativeMath = false;
+    } else if (A->getOption().matches(options::OPT_fsigned_zeros)) {
+      SignedZeros = true;
+      AssociativeMath = false;
+    } else if (A->getOption().matches(options::OPT_fno_signed_zeros)) {
+      SignedZeros = NeedIEEE = false;
     }
     A->claim();
   }
@@ -1005,6 +1021,17 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
   LowerCmdArgs.push_back("-y"); LowerCmdArgs.push_back("163"); LowerCmdArgs.push_back("0xc0000000");
   LowerCmdArgs.push_back("-x"); LowerCmdArgs.push_back("189"); LowerCmdArgs.push_back("0x10");
   LowerCmdArgs.push_back("-y"); LowerCmdArgs.push_back("189"); LowerCmdArgs.push_back("0x4000000");
+
+  if (!SignedZeros) {
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("216");
+    LowerCmdArgs.push_back("0x8");
+  }
+  if (AssociativeMath) {
+    LowerCmdArgs.push_back("-x");
+    LowerCmdArgs.push_back("216");
+    LowerCmdArgs.push_back("0x10");
+  }
 
   // Remove "noinline" attriblute
   LowerCmdArgs.push_back("-x"); LowerCmdArgs.push_back("183"); LowerCmdArgs.push_back("0x10");

--- a/clang/test/Driver/flang/reassoc.f90
+++ b/clang/test/Driver/flang/reassoc.f90
@@ -1,0 +1,59 @@
+! REQUIRES: classic_flang
+
+! Tests for flags which generate nsw, reassoc attributes
+
+! RUN: %flang -Kieee %s -### 2>&1 | FileCheck --check-prefixes=IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -Knoieee %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -ffast-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fno-fast-math %s -### 2>&1 | FileCheck --check-prefixes=NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -frelaxed-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fassociative-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_RELAXED,REASSOC_NSZ %s
+! RUN: %flang -fno-associative-math %s -### 2>&1 | FileCheck --check-prefixes=NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fsigned-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fno-signed-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NSZ %s
+
+! RUN: %flang -fno-associative-math -fno-signed-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NSZ %s
+! RUN: %flang -fno-associative-math -fsigned-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fassociative-math -fno-signed-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_RELAXED,REASSOC_NSZ %s
+! RUN: %flang -fassociative-math -fsigned-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+
+! RUN: %flang -Kieee -fassociative-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_RELAXED,REASSOC_NSZ %s
+! RUN: %flang -Kieee -fno-associative-math %s -### 2>&1 | FileCheck --check-prefixes=IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -Kieee -fsigned-zeros %s -### 2>&1 | FileCheck --check-prefixes=IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -Kieee -fno-signed-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NSZ %s
+! RUN: %flang -ffast-math -fassociative-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_RELAXED,REASSOC_NSZ %s
+! RUN: %flang -ffast-math -fno-associative-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -ffast-math -fsigned-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -ffast-math -fno-signed-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_RELAXED,NO_REASSOC,NSZ %s
+! RUN: %flang -frelaxed-math -fassociative-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,REASSOC_NSZ %s
+! RUN: %flang -frelaxed-math -fno-associative-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -frelaxed-math -fsigned-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -frelaxed-math -fno-signed-zeros %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_REASSOC,NSZ %s
+
+! RUN: %flang -fassociative-math -Kieee %s -### 2>&1 | FileCheck --check-prefixes=IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fno-associative-math -Kieee %s -### 2>&1 | FileCheck --check-prefixes=IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fsigned-zeros -Kieee %s -### 2>&1 | FileCheck --check-prefixes=IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fno-signed-zeros -Kieee %s -### 2>&1 | FileCheck --check-prefixes=IEEE,NO_FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fassociative-math -ffast-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_RELAXED,REASSOC_NSZ %s
+! RUN: %flang -fno-associative-math -ffast-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fsigned-zeros -ffast-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,FAST,NO_RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fno-signed-zeros -ffast-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_RELAXED,NO_REASSOC,NSZ %s
+! RUN: %flang -fassociative-math -frelaxed-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,REASSOC_NSZ %s
+! RUN: %flang -fno-associative-math -frelaxed-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fsigned-zeros -frelaxed-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,RELAXED,NO_REASSOC,NO_NSZ %s
+! RUN: %flang -fno-signed-zeros -frelaxed-math %s -### 2>&1 | FileCheck --check-prefixes=NO_IEEE,NO_FAST,NO_REASSOC,NSZ %s
+
+! IEEE: {{.*}}flang2{{.*}} "-ieee" "1"
+! NO_IEEE-NOT: {{.*}}flang2{{.*}} "-ieee" "1"
+
+! FAST: {{.*}}flang2{{.*}} "-x" "216" "1"
+! NO_FAST-NOT: {{.*}}flang2{{.*}} "-x" "216" "1"
+
+! RELAXED: {{.*}}flang2{{.*}} "-x" "15" "0x400"
+! NO_RELAXED-NOT: {{.*}}flang2{{.*}} "-x" "15" "0x400"
+
+! REASSOC_NSZ: {{.*}}flang2{{.*}} "-x" "216" "0x8" "-x" "216" "0x10"
+! NO_REASSOC-NOT: {{.*}}flang2{{.*}} "-x" "216" "0x10"
+
+! NSZ: {{.*}}flang2{{.*}} "-x" "216" "0x8"
+! NO_NSZ-NOT: {{.*}}flang2{{.*}} "-x" "216" "0x8"


### PR DESCRIPTION
This patch adds code to generate the driver flags so that llvm bridge in flang2 can generate the nsz, reassoc attributes to arithmetic instructions. Also included is a testcase.

Associated commit for the flang side: https://github.com/flang-compiler/flang/pull/1268