### PR TITLE
[build] Stop caching AArch64 Docker image layers

### DIFF
--- a/.github/workflows/build_push_docker_image_Ubuntu20.yml
+++ b/.github/workflows/build_push_docker_image_Ubuntu20.yml
@@ -22,14 +22,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Log in
         uses: docker/login-action@v1
         with:
@@ -42,20 +34,9 @@ jobs:
         with:
           file: .github/workflows/Ubuntu20Dockerfile
           push: true
+          no-cache: true
           context: .github/workflows
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
           tags: ghcr.io/${{ github.repository_owner }}/ubuntu20-flang-${{ steps.extract_branch.outputs.branch }}:latest
           platforms: linux/arm64
           build-args: |
             BRANCH_NAME=${{ steps.extract_branch.outputs.branch }}
-
-      # This ugly bit is necessary if you don't want your cache to grow forever
-      # till it hits GitHub's limit of 5GB.
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
The "Pre-compile llvm ARM64" workflow tries to cache Docker image layers to avoid rebuilding the same content over and over, as PRs are merged into the release branches. Mysteriously, in older release branches the workflow was not successfully caching layers, while in release_14x, it is too successful, resulting in the same image being uploaded for successive commit hashes. The actual build process is not too time-consuming (about 15 minutes) so it is safer and simpler to turn off caching completely.