### PR TITLE
[Driver] Remove the "-lompstub" in the driver (release_13x)

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -994,8 +994,6 @@ void ToolChain::AddFortranStdlibLibArgs(const ArgList &Args,
   CmdArgs.push_back("-lpgmath");
   if (useOpenMP)
     CmdArgs.push_back("-lomp");
-  else
-    CmdArgs.push_back("-lompstub");
   if (staticFlangLibs)
     CmdArgs.push_back("-Bdynamic");
 


### PR DESCRIPTION
In some workloads, users get "-lompstub" by running "flang test.f90 -v"
and link it explicitly, which may cause failure when compiling
programs with OpenMP (flang -fopenmp test.f90 -lompstub).

There is no runtime call in ompstub.c generated when "-fopenmp" is not
added to compile the program. When "-fopenmp" is added to compile the
program, the runtime in llvm/openmp(libomp.so) will be used. If users
use some runtime library routines such as "omp_get_thread_num" and
compiles it without the option "-fopenmp", both gfortran and ifort
report errors of "undefined reference to ...". After remove "-lompstub"
in the driver, classic-flang reports the error, too. So, it's safe to
remove the "-lompstub" in the driver.