### PR TITLE
[llvm] Provide separate veclib mapping of PGMATH functions for AArch64 (release_14x)

### DIFF
--- a/clang/test/CodeGen/libpgmath-logfun-aarch64.ll
+++ b/clang/test/CodeGen/libpgmath-logfun-aarch64.ll
@@ -1,0 +1,60 @@
+; REQUIRES: aarch64-registered-target
+
+; RUN: %clang -target aarch64-unknown-linux-gnu -Ofast -S %s -o - | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @fun_(i64* nocapture %z) local_unnamed_addr #0 {
+L.entry:
+  %0 = bitcast i64* %z to i8*
+  %1 = bitcast i64* %z to float*
+  %2 = load float, float* %1, align 4
+  %3 = fpext float %2 to double
+  %4 = fadd double %3, 5.000000e-01
+  %5 = tail call double @__pd_log_1(double %4) #1
+  %6 = fptrunc double %5 to float
+  %7 = tail call float @__ps_exp_1(float %6) #2
+  store float %7, float* %1, align 4
+  %8 = getelementptr i8, i8* %0, i64 4
+  %9 = bitcast i8* %8 to float*
+  %10 = load float, float* %9, align 4
+  %11 = fpext float %10 to double
+  %12 = fadd double %11, 5.000000e-01
+  %13 = tail call double @__pd_log_1(double %12) #1
+  %14 = fptrunc double %13 to float
+  %15 = tail call float @__ps_exp_1(float %14) #2
+  store float %15, float* %9, align 4
+  %16 = getelementptr i64, i64* %z, i64 1
+  %17 = bitcast i64* %16 to float*
+  %18 = load float, float* %17, align 4
+  %19 = fpext float %18 to double
+  %20 = fadd double %19, 5.000000e-01
+  %21 = tail call double @__pd_log_1(double %20) #1
+  %22 = fptrunc double %21 to float
+  %23 = tail call float @__ps_exp_1(float %22) #2
+  store float %23, float* %17, align 4
+  %24 = getelementptr i8, i8* %0, i64 12
+  %25 = bitcast i8* %24 to float*
+  %26 = load float, float* %25, align 4
+  %27 = fpext float %26 to double
+  %28 = fadd double %27, 5.000000e-01
+  %29 = tail call double @__pd_log_1(double %28) #1
+  %30 = fptrunc double %29 to float
+  %31 = tail call float @__ps_exp_1(float %30) #2
+  store float %31, float* %25, align 4
+  ret void
+
+; CHECK-NOT: __pd_log_4
+; CHECK: __pd_log_1
+; CHECK: __pd_log_1
+; CHECK: __pd_log_1
+; CHECK: __pd_log_1
+}
+
+; Function Attrs: nounwind readnone willreturn
+declare float @__ps_exp_1(float) #0
+
+; Function Attrs: nounwind readnone willreturn
+declare double @__pd_log_1(double) #0
+
+attributes #0 = { nounwind readnone willreturn }

--- a/clang/test/CodeGen/libpgmath-logfun-x86_64.ll
+++ b/clang/test/CodeGen/libpgmath-logfun-x86_64.ll
@@ -1,0 +1,57 @@
+; REQUIRES: x86-registered-target
+
+; RUN: %clang -target x86_64-unknown-linux-gnu -msse -Ofast -S %s -o - | FileCheck %s
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @fun_(i64* nocapture %z) local_unnamed_addr #0 {
+L.entry:
+  %0 = bitcast i64* %z to i8*
+  %1 = bitcast i64* %z to float*
+  %2 = load float, float* %1, align 4
+  %3 = fpext float %2 to double
+  %4 = fadd double %3, 5.000000e-01
+  %5 = tail call double @__pd_log_1(double %4) #1
+  %6 = fptrunc double %5 to float
+  %7 = tail call float @__ps_exp_1(float %6) #2
+  store float %7, float* %1, align 4
+  %8 = getelementptr i8, i8* %0, i64 4
+  %9 = bitcast i8* %8 to float*
+  %10 = load float, float* %9, align 4
+  %11 = fpext float %10 to double
+  %12 = fadd double %11, 5.000000e-01
+  %13 = tail call double @__pd_log_1(double %12) #1
+  %14 = fptrunc double %13 to float
+  %15 = tail call float @__ps_exp_1(float %14) #2
+  store float %15, float* %9, align 4
+  %16 = getelementptr i64, i64* %z, i64 1
+  %17 = bitcast i64* %16 to float*
+  %18 = load float, float* %17, align 4
+  %19 = fpext float %18 to double
+  %20 = fadd double %19, 5.000000e-01
+  %21 = tail call double @__pd_log_1(double %20) #1
+  %22 = fptrunc double %21 to float
+  %23 = tail call float @__ps_exp_1(float %22) #2
+  store float %23, float* %17, align 4
+  %24 = getelementptr i8, i8* %0, i64 12
+  %25 = bitcast i8* %24 to float*
+  %26 = load float, float* %25, align 4
+  %27 = fpext float %26 to double
+  %28 = fadd double %27, 5.000000e-01
+  %29 = tail call double @__pd_log_1(double %28) #1
+  %30 = fptrunc double %29 to float
+  %31 = tail call float @__ps_exp_1(float %30) #2
+  store float %31, float* %25, align 4
+  ret void
+
+; CHECK-NOT: __pd_log_1
+; CHECK: __pd_log_4
+}
+
+; Function Attrs: nounwind readnone willreturn
+declare float @__ps_exp_1(float) #0
+
+; Function Attrs: nounwind readnone willreturn
+declare double @__pd_log_1(double) #0
+
+attributes #0 = { nounwind readnone willreturn }

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -12,6 +12,7 @@
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/ADT/Triple.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Module.h"
@@ -20,7 +21,6 @@
 
 namespace llvm {
 template <typename T> class ArrayRef;
-class Triple;
 
 /// Describes a possible vectorization of a function.
 /// Function 'VectorFnName' is equivalent to 'ScalarFnName' vectorized
@@ -77,6 +77,8 @@ class TargetLibraryInfoImpl {
   /// F, regardless of whether the function is available.
   bool isValidProtoForLibFunc(const FunctionType &FTy, LibFunc F,
                               const Module &M) const;
+
+  Triple T;
 
 public:
   /// List of known vector-functions libraries.

--- a/llvm/include/llvm/Analysis/VecFuncs.def
+++ b/llvm/include/llvm/Analysis/VecFuncs.def
@@ -466,6 +466,620 @@ TLI_DEFINE_VECFUNC("__exp2f_finite", "__svml_exp2f4", FIXED(4))
 TLI_DEFINE_VECFUNC("__exp2f_finite", "__svml_exp2f8", FIXED(8))
 TLI_DEFINE_VECFUNC("__exp2f_finite", "__svml_exp2f16", FIXED(16))
 
+#elif defined(TLI_DEFINE_PGMATH_AARCH64_VECFUNCS)
+// Classic flang libpgmath library's Vector Functions for AArch64
+
+TLI_DEFINE_VECFUNC("__fd_sin_1", "__fd_sin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_sin_1", "__fs_sin_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_sin_1", "__pd_sin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_sin_1", "__ps_sin_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_sin_1", "__rd_sin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_sin_1", "__rs_sin_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_cos_1", "__fd_cos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_cos_1", "__fs_cos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_cos_1", "__pd_cos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_tan_1", "__pd_tan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_tan_1", "__ps_tan_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_tan_1", "__rd_tan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_tan_1", "__rs_tan_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_sinh_1", "__fd_sinh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_sinh_1", "__fs_sinh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_sinh_1", "__pd_sinh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_sinh_1", "__ps_sinh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_sinh_1", "__rd_sinh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_sinh_1", "__rs_sinh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_cosh_1", "__fd_cosh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_cosh_1", "__fs_cosh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_cosh_1", "__pd_cosh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_cosh_1", "__ps_cosh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_cosh_1", "__rd_cosh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_cosh_1", "__rs_cosh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_tanh_1", "__fd_tanh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_tanh_1", "__fs_tanh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_tanh_1", "__pd_tanh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_tanh_1", "__ps_tanh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_tanh_1", "__rd_tanh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_tanh_1", "__rs_tanh_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_asin_1", "__fd_asin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_asin_1", "__fs_asin_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_asin_1", "__pd_asin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_asin_1", "__ps_asin_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_asin_1", "__rd_asin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_asin_1", "__rs_asin_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_acos_1", "__fd_acos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_acos_1", "__fs_acos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_acos_1", "__pd_acos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_acos_1", "__ps_acos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_acos_1", "__rd_acos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_acos_1", "__rs_acos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_atan_1", "__fd_atan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_atan_1", "__fs_atan_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_atan_1", "__pd_atan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_atan_1", "__ps_atan_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_atan_1", "__rd_atan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_atan_1", "__rs_atan_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_atan2_1", "__fd_atan2_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_atan2_1", "__fs_atan2_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_atan2_1", "__pd_atan2_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_atan2_1", "__ps_atan2_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_atan2_1", "__rd_atan2_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_atan2_1", "__rs_atan2_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_pow_1", "__fd_pow_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_pow_1", "__fs_pow_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_pow_1", "__pd_pow_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_pow_1", "__ps_pow_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_pow_1", "__rd_pow_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_pow_1", "__rs_pow_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fs_powi_1", "__fs_powi_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__ps_powi_1", "__ps_powi_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rs_powi_1", "__rs_powi_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_powi1_1", "__fd_powi1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_powi1_1", "__fs_powi1_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_powi1_1", "__pd_powi1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_powi1_1", "__ps_powi1_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_powi1_1", "__rd_powi1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_powi1_1", "__rs_powi1_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_powk_1", "__fd_powk_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_powk_1", "__fs_powk_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_powk_1", "__pd_powk_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_powk_1", "__ps_powk_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_powk_1", "__rd_powk_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_powk_1", "__rs_powk_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_powk1_1", "__fd_powk1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_powk1_1", "__fs_powk1_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_powk1_1", "__pd_powk1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_powk1_1", "__ps_powk1_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_powk1_1", "__rd_powk1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_powk1_1", "__rs_powk1_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_log10_1", "__fd_log10_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_log10_1", "__fs_log10_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_log10_1", "__pd_log10_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_log10_1", "__ps_log10_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_log10_1", "__rd_log10_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_log10_1", "__rs_log10_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_log_1", "__fd_log_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_log_1", "__fs_log_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_log_1", "__pd_log_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_log_1", "__ps_log_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_log_1", "__rd_log_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_log_1", "__rs_log_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__fd_exp_1", "__fd_exp_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_exp_1", "__fs_exp_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_exp_1", "__pd_exp_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_exp_1", "__ps_exp_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_exp_1", "__rd_exp_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_4", FIXED(4))
+
+#elif defined(TLI_DEFINE_PGMATH_X86_VECFUNCS)
+// Classic flang libpgmath library's Vector Functions for X86
+
+TLI_DEFINE_VECFUNC("__fd_sin_1", "__fd_sin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_sin_1", "__fd_sin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_sin_1", "__fd_sin_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_sin_1", "__fs_sin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_sin_1", "__fs_sin_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_sin_1", "__fs_sin_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_sin_1", "__pd_sin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_sin_1", "__pd_sin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_sin_1", "__pd_sin_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_sin_1", "__ps_sin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_sin_1", "__ps_sin_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_sin_1", "__ps_sin_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_sin_1", "__rd_sin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_sin_1", "__rd_sin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_sin_1", "__rd_sin_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_sin_1", "__rs_sin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_sin_1", "__rs_sin_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_sin_1", "__rs_sin_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_cos_1", "__fd_cos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_cos_1", "__fd_cos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_cos_1", "__fd_cos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_cos_1", "__fs_cos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_cos_1", "__fs_cos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_cos_1", "__fs_cos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_cos_1", "__pd_cos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_cos_1", "__pd_cos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_cos_1", "__pd_cos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_tan_1", "__pd_tan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_tan_1", "__pd_tan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_tan_1", "__pd_tan_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_tan_1", "__ps_tan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_tan_1", "__ps_tan_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_tan_1", "__ps_tan_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_tan_1", "__rd_tan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_tan_1", "__rd_tan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_tan_1", "__rd_tan_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_tan_1", "__rs_tan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_tan_1", "__rs_tan_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_tan_1", "__rs_tan_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_sinh_1", "__fd_sinh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_sinh_1", "__fd_sinh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_sinh_1", "__fd_sinh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_sinh_1", "__fs_sinh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_sinh_1", "__fs_sinh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_sinh_1", "__fs_sinh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_sinh_1", "__pd_sinh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_sinh_1", "__pd_sinh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_sinh_1", "__pd_sinh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_sinh_1", "__ps_sinh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_sinh_1", "__ps_sinh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_sinh_1", "__ps_sinh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_sinh_1", "__rd_sinh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_sinh_1", "__rd_sinh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_sinh_1", "__rd_sinh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_sinh_1", "__rs_sinh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_sinh_1", "__rs_sinh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_sinh_1", "__rs_sinh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_cosh_1", "__fd_cosh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_cosh_1", "__fd_cosh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_cosh_1", "__fd_cosh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_cosh_1", "__fs_cosh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_cosh_1", "__fs_cosh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_cosh_1", "__fs_cosh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_cosh_1", "__pd_cosh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_cosh_1", "__pd_cosh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_cosh_1", "__pd_cosh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_cosh_1", "__ps_cosh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_cosh_1", "__ps_cosh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_cosh_1", "__ps_cosh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_cosh_1", "__rd_cosh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_cosh_1", "__rd_cosh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_cosh_1", "__rd_cosh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_cosh_1", "__rs_cosh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_cosh_1", "__rs_cosh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_cosh_1", "__rs_cosh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_tanh_1", "__fd_tanh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_tanh_1", "__fd_tanh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_tanh_1", "__fd_tanh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_tanh_1", "__fs_tanh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_tanh_1", "__fs_tanh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_tanh_1", "__fs_tanh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_tanh_1", "__pd_tanh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_tanh_1", "__pd_tanh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_tanh_1", "__pd_tanh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_tanh_1", "__ps_tanh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_tanh_1", "__ps_tanh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_tanh_1", "__ps_tanh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_tanh_1", "__rd_tanh_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_tanh_1", "__rd_tanh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_tanh_1", "__rd_tanh_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_tanh_1", "__rs_tanh_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_tanh_1", "__rs_tanh_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_tanh_1", "__rs_tanh_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_asin_1", "__fd_asin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_asin_1", "__fd_asin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_asin_1", "__fd_asin_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_asin_1", "__fs_asin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_asin_1", "__fs_asin_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_asin_1", "__fs_asin_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_asin_1", "__pd_asin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_asin_1", "__pd_asin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_asin_1", "__pd_asin_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_asin_1", "__ps_asin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_asin_1", "__ps_asin_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_asin_1", "__ps_asin_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_asin_1", "__rd_asin_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_asin_1", "__rd_asin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_asin_1", "__rd_asin_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_asin_1", "__rs_asin_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_asin_1", "__rs_asin_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_asin_1", "__rs_asin_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_acos_1", "__fd_acos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_acos_1", "__fd_acos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_acos_1", "__fd_acos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_acos_1", "__fs_acos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_acos_1", "__fs_acos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_acos_1", "__fs_acos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_acos_1", "__pd_acos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_acos_1", "__pd_acos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_acos_1", "__pd_acos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_acos_1", "__ps_acos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_acos_1", "__ps_acos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_acos_1", "__ps_acos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_acos_1", "__rd_acos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_acos_1", "__rd_acos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_acos_1", "__rd_acos_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_acos_1", "__rs_acos_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_acos_1", "__rs_acos_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_acos_1", "__rs_acos_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_atan_1", "__fd_atan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_atan_1", "__fd_atan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_atan_1", "__fd_atan_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_atan_1", "__fs_atan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_atan_1", "__fs_atan_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_atan_1", "__fs_atan_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_atan_1", "__pd_atan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_atan_1", "__pd_atan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_atan_1", "__pd_atan_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_atan_1", "__ps_atan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_atan_1", "__ps_atan_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_atan_1", "__ps_atan_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_atan_1", "__rd_atan_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_atan_1", "__rd_atan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_atan_1", "__rd_atan_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_atan_1", "__rs_atan_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_atan_1", "__rs_atan_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_atan_1", "__rs_atan_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_atan2_1", "__fd_atan2_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_atan2_1", "__fd_atan2_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_atan2_1", "__fd_atan2_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_atan2_1", "__fs_atan2_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_atan2_1", "__fs_atan2_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_atan2_1", "__fs_atan2_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_atan2_1", "__pd_atan2_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_atan2_1", "__pd_atan2_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_atan2_1", "__pd_atan2_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_atan2_1", "__ps_atan2_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_atan2_1", "__ps_atan2_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_atan2_1", "__ps_atan2_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_atan2_1", "__rd_atan2_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_atan2_1", "__rd_atan2_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_atan2_1", "__rd_atan2_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_atan2_1", "__rs_atan2_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_atan2_1", "__rs_atan2_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_atan2_1", "__rs_atan2_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_pow_1", "__fd_pow_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_pow_1", "__fd_pow_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_pow_1", "__fd_pow_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_pow_1", "__fs_pow_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_pow_1", "__fs_pow_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_pow_1", "__fs_pow_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_pow_1", "__pd_pow_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_pow_1", "__pd_pow_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_pow_1", "__pd_pow_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_pow_1", "__ps_pow_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_pow_1", "__ps_pow_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_pow_1", "__ps_pow_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_pow_1", "__rd_pow_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_pow_1", "__rd_pow_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_pow_1", "__rd_pow_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_pow_1", "__rs_pow_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_pow_1", "__rs_pow_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_pow_1", "__rs_pow_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fs_powi_1", "__fs_powi_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_powi_1", "__fs_powi_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_powi_1", "__fs_powi_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__ps_powi_1", "__ps_powi_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_powi_1", "__ps_powi_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_powi_1", "__ps_powi_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rs_powi_1", "__rs_powi_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_powi_1", "__rs_powi_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_powi_1", "__rs_powi_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_powi1_1", "__fd_powi1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_powi1_1", "__fd_powi1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_powi1_1", "__fd_powi1_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_powi1_1", "__fs_powi1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_powi1_1", "__fs_powi1_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_powi1_1", "__fs_powi1_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_powi1_1", "__pd_powi1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_powi1_1", "__pd_powi1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_powi1_1", "__pd_powi1_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_powi1_1", "__ps_powi1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_powi1_1", "__ps_powi1_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_powi1_1", "__ps_powi1_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_powi1_1", "__rd_powi1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_powi1_1", "__rd_powi1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_powi1_1", "__rd_powi1_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_powi1_1", "__rs_powi1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_powi1_1", "__rs_powi1_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_powi1_1", "__rs_powi1_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_powk_1", "__fd_powk_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_powk_1", "__fd_powk_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_powk_1", "__fd_powk_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_powk_1", "__fs_powk_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_powk_1", "__fs_powk_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_powk_1", "__fs_powk_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_powk_1", "__pd_powk_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_powk_1", "__pd_powk_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_powk_1", "__pd_powk_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_powk_1", "__ps_powk_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_powk_1", "__ps_powk_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_powk_1", "__ps_powk_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_powk_1", "__rd_powk_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_powk_1", "__rd_powk_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_powk_1", "__rd_powk_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_powk_1", "__rs_powk_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_powk_1", "__rs_powk_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_powk_1", "__rs_powk_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_powk1_1", "__fd_powk1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_powk1_1", "__fd_powk1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_powk1_1", "__fd_powk1_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_powk1_1", "__fs_powk1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_powk1_1", "__fs_powk1_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_powk1_1", "__fs_powk1_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_powk1_1", "__pd_powk1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_powk1_1", "__pd_powk1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_powk1_1", "__pd_powk1_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_powk1_1", "__ps_powk1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_powk1_1", "__ps_powk1_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_powk1_1", "__ps_powk1_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_powk1_1", "__rd_powk1_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_powk1_1", "__rd_powk1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_powk1_1", "__rd_powk1_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_powk1_1", "__rs_powk1_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_powk1_1", "__rs_powk1_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_powk1_1", "__rs_powk1_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_log10_1", "__fd_log10_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_log10_1", "__fd_log10_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_log10_1", "__fd_log10_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_log10_1", "__fs_log10_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_log10_1", "__fs_log10_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_log10_1", "__fs_log10_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_log10_1", "__pd_log10_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_log10_1", "__pd_log10_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_log10_1", "__pd_log10_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_log10_1", "__ps_log10_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_log10_1", "__ps_log10_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_log10_1", "__ps_log10_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_log10_1", "__rd_log10_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_log10_1", "__rd_log10_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_log10_1", "__rd_log10_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_log10_1", "__rs_log10_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_log10_1", "__rs_log10_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_log10_1", "__rs_log10_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fd_log_1", "__fd_log_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fd_log_1", "__fd_log_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fd_log_1", "__fd_log_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__fs_log_1", "__fs_log_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_log_1", "__fs_log_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_log_1", "__fs_log_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_log_1", "__pd_log_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_log_1", "__pd_log_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_log_1", "__pd_log_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_log_1", "__ps_log_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_log_1", "__ps_log_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_log_1", "__ps_log_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_log_1", "__rd_log_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_log_1", "__rd_log_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_log_1", "__rd_log_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_log_1", "__rs_log_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_log_1", "__rs_log_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_log_1", "__rs_log_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__fs_exp_1", "__fs_exp_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__fs_exp_1", "__fs_exp_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__fs_exp_1", "__fs_exp_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__pd_exp_1", "__pd_exp_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__pd_exp_1", "__pd_exp_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__pd_exp_1", "__pd_exp_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__ps_exp_1", "__ps_exp_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__ps_exp_1", "__ps_exp_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__ps_exp_1", "__ps_exp_16", FIXED(16))
+
+TLI_DEFINE_VECFUNC("__rd_exp_1", "__rd_exp_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rd_exp_1", "__rd_exp_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rd_exp_1", "__rd_exp_8", FIXED(8))
+
+TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_4", FIXED(4))
+TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_8", FIXED(8))
+TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_16", FIXED(16))
+
 #else
 #error "Must choose which vector library functions are to be defined."
 #endif
@@ -477,3 +1091,5 @@ TLI_DEFINE_VECFUNC("__exp2f_finite", "__svml_exp2f16", FIXED(16))
 #undef TLI_DEFINE_MASSV_VECFUNCS
 #undef TLI_DEFINE_SVML_VECFUNCS
 #undef TLI_DEFINE_MASSV_VECFUNCS_NAMES
+#undef TLI_DEFINE_PGMATH_AARCH64_VECFUNCS
+#undef TLI_DEFINE_PGMATH_X86_VECFUNCS

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -831,14 +831,14 @@ static void initialize(TargetLibraryInfoImpl &TLI, const Triple &T,
   TLI.addVectorizableFunctionsFromVecLib(ClVectorLibrary);
 }
 
-TargetLibraryInfoImpl::TargetLibraryInfoImpl() {
+TargetLibraryInfoImpl::TargetLibraryInfoImpl() : T(Triple()) {
   // Default to everything being available.
   memset(AvailableArray, -1, sizeof(AvailableArray));
 
-  initialize(*this, Triple(), StandardNames);
+  initialize(*this, T, StandardNames);
 }
 
-TargetLibraryInfoImpl::TargetLibraryInfoImpl(const Triple &T) {
+TargetLibraryInfoImpl::TargetLibraryInfoImpl(const Triple &T) : T(T) {
   // Default to everything being available.
   memset(AvailableArray, -1, sizeof(AvailableArray));
 
@@ -849,7 +849,7 @@ TargetLibraryInfoImpl::TargetLibraryInfoImpl(const TargetLibraryInfoImpl &TLI)
     : CustomNames(TLI.CustomNames), ShouldExtI32Param(TLI.ShouldExtI32Param),
       ShouldExtI32Return(TLI.ShouldExtI32Return),
       ShouldSignExtI32Param(TLI.ShouldSignExtI32Param),
-      SizeOfInt(TLI.SizeOfInt) {
+      SizeOfInt(TLI.SizeOfInt), T(TLI.T) {
   memcpy(AvailableArray, TLI.AvailableArray, sizeof(AvailableArray));
   VectorDescs = TLI.VectorDescs;
   ScalarDescs = TLI.ScalarDescs;
@@ -860,7 +860,7 @@ TargetLibraryInfoImpl::TargetLibraryInfoImpl(TargetLibraryInfoImpl &&TLI)
       ShouldExtI32Param(TLI.ShouldExtI32Param),
       ShouldExtI32Return(TLI.ShouldExtI32Return),
       ShouldSignExtI32Param(TLI.ShouldSignExtI32Param),
-      SizeOfInt(TLI.SizeOfInt) {
+      SizeOfInt(TLI.SizeOfInt), T(TLI.T) {
   std::move(std::begin(TLI.AvailableArray), std::end(TLI.AvailableArray),
             AvailableArray);
   VectorDescs = TLI.VectorDescs;
@@ -873,6 +873,7 @@ TargetLibraryInfoImpl &TargetLibraryInfoImpl::operator=(const TargetLibraryInfoI
   ShouldExtI32Return = TLI.ShouldExtI32Return;
   ShouldSignExtI32Param = TLI.ShouldSignExtI32Param;
   SizeOfInt = TLI.SizeOfInt;
+  T = TLI.T;
   memcpy(AvailableArray, TLI.AvailableArray, sizeof(AvailableArray));
   return *this;
 }
@@ -883,6 +884,7 @@ TargetLibraryInfoImpl &TargetLibraryInfoImpl::operator=(TargetLibraryInfoImpl &&
   ShouldExtI32Return = TLI.ShouldExtI32Return;
   ShouldSignExtI32Param = TLI.ShouldSignExtI32Param;
   SizeOfInt = TLI.SizeOfInt;
+  T = TLI.T;
   std::move(std::begin(TLI.AvailableArray), std::end(TLI.AvailableArray),
             AvailableArray);
   return *this;
@@ -1889,448 +1891,19 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
   // Based on the size of vector registers available and the size of data, the
   // vector width should be chosen correctly.
   case PGMATH: {
-    const VecDesc VecFuncs[] = {
-        {"__fd_sin_1", "__fd_sin_2", FIXED(2)},
-        {"__fd_sin_1", "__fd_sin_4", FIXED(4)},
-        {"__fd_sin_1", "__fd_sin_8", FIXED(8)},
-
-        {"__fs_sin_1", "__fs_sin_4", FIXED(4)},
-        {"__fs_sin_1", "__fs_sin_8", FIXED(8)},
-        {"__fs_sin_1", "__fs_sin_16", FIXED(16)},
-
-        {"__pd_sin_1", "__pd_sin_2", FIXED(2)},
-        {"__pd_sin_1", "__pd_sin_4", FIXED(4)},
-        {"__pd_sin_1", "__pd_sin_8", FIXED(8)},
-
-        {"__ps_sin_1", "__ps_sin_4", FIXED(4)},
-        {"__ps_sin_1", "__ps_sin_8", FIXED(8)},
-        {"__ps_sin_1", "__ps_sin_16", FIXED(16)},
-
-        {"__rd_sin_1", "__rd_sin_2", FIXED(2)},
-        {"__rd_sin_1", "__rd_sin_4", FIXED(4)},
-        {"__rd_sin_1", "__rd_sin_8", FIXED(8)},
-
-        {"__rs_sin_1", "__rs_sin_4", FIXED(4)},
-        {"__rs_sin_1", "__rs_sin_8", FIXED(8)},
-        {"__rs_sin_1", "__rs_sin_16", FIXED(16)},
-
-        {"__fd_cos_1", "__fd_cos_2", FIXED(2)},
-        {"__fd_cos_1", "__fd_cos_4", FIXED(4)},
-        {"__fd_cos_1", "__fd_cos_8", FIXED(8)},
-
-        {"__fs_cos_1", "__fs_cos_4", FIXED(4)},
-        {"__fs_cos_1", "__fs_cos_8", FIXED(8)},
-        {"__fs_cos_1", "__fs_cos_16", FIXED(16)},
-
-        {"__pd_cos_1", "__pd_cos_2", FIXED(2)},
-        {"__pd_cos_1", "__pd_cos_4", FIXED(4)},
-        {"__pd_cos_1", "__pd_cos_8", FIXED(8)},
-
-        {"__ps_cos_1", "__ps_cos_4", FIXED(4)},
-        {"__ps_cos_1", "__ps_cos_8", FIXED(8)},
-        {"__ps_cos_1", "__ps_cos_16", FIXED(16)},
-
-        {"__rd_cos_1", "__rd_cos_2", FIXED(2)},
-        {"__rd_cos_1", "__rd_cos_4", FIXED(4)},
-        {"__rd_cos_1", "__rd_cos_8", FIXED(8)},
-
-        {"__rs_cos_1", "__rs_cos_4", FIXED(4)},
-        {"__rs_cos_1", "__rs_cos_8", FIXED(8)},
-        {"__rs_cos_1", "__rs_cos_16", FIXED(16)},
-
-        {"__fd_sincos_1", "__fd_sincos_2", FIXED(2)},
-        {"__fd_sincos_1", "__fd_sincos_4", FIXED(4)},
-        {"__fd_sincos_1", "__fd_sincos_8", FIXED(8)},
-
-        {"__fs_sincos_1", "__fs_sincos_4", FIXED(4)},
-        {"__fs_sincos_1", "__fs_sincos_8", FIXED(8)},
-        {"__fs_sincos_1", "__fs_sincos_16", FIXED(16)},
-
-        {"__pd_sincos_1", "__pd_sincos_2", FIXED(2)},
-        {"__pd_sincos_1", "__pd_sincos_4", FIXED(4)},
-        {"__pd_sincos_1", "__pd_sincos_8", FIXED(8)},
-
-        {"__ps_sincos_1", "__ps_sincos_4", FIXED(4)},
-        {"__ps_sincos_1", "__ps_sincos_8", FIXED(8)},
-        {"__ps_sincos_1", "__ps_sincos_16", FIXED(16)},
-
-        {"__rd_sincos_1", "__rd_sincos_2", FIXED(2)},
-        {"__rd_sincos_1", "__rd_sincos_4", FIXED(4)},
-        {"__rd_sincos_1", "__rd_sincos_8", FIXED(8)},
-
-        {"__rs_sincos_1", "__rs_sincos_4", FIXED(4)},
-        {"__rs_sincos_1", "__rs_sincos_8", FIXED(8)},
-        {"__rs_sincos_1", "__rs_sincos_16", FIXED(16)},
-
-        {"__fd_tan_1", "__fd_tan_2", FIXED(2)},
-        {"__fd_tan_1", "__fd_tan_4", FIXED(4)},
-        {"__fd_tan_1", "__fd_tan_8", FIXED(8)},
-
-        {"__fs_tan_1", "__fs_tan_4", FIXED(4)},
-        {"__fs_tan_1", "__fs_tan_8", FIXED(8)},
-        {"__fs_tan_1", "__fs_tan_16", FIXED(16)},
-
-        {"__pd_tan_1", "__pd_tan_2", FIXED(2)},
-        {"__pd_tan_1", "__pd_tan_4", FIXED(4)},
-        {"__pd_tan_1", "__pd_tan_8", FIXED(8)},
-
-        {"__ps_tan_1", "__ps_tan_4", FIXED(4)},
-        {"__ps_tan_1", "__ps_tan_8", FIXED(8)},
-        {"__ps_tan_1", "__ps_tan_16", FIXED(16)},
-
-        {"__rd_tan_1", "__rd_tan_2", FIXED(2)},
-        {"__rd_tan_1", "__rd_tan_4", FIXED(4)},
-        {"__rd_tan_1", "__rd_tan_8", FIXED(8)},
-
-        {"__rs_tan_1", "__rs_tan_4", FIXED(4)},
-        {"__rs_tan_1", "__rs_tan_8", FIXED(8)},
-        {"__rs_tan_1", "__rs_tan_16", FIXED(16)},
-
-        {"__fd_sinh_1", "__fd_sinh_2", FIXED(2)},
-        {"__fd_sinh_1", "__fd_sinh_4", FIXED(4)},
-        {"__fd_sinh_1", "__fd_sinh_8", FIXED(8)},
-
-        {"__fs_sinh_1", "__fs_sinh_4", FIXED(4)},
-        {"__fs_sinh_1", "__fs_sinh_8", FIXED(8)},
-        {"__fs_sinh_1", "__fs_sinh_16", FIXED(16)},
-
-        {"__pd_sinh_1", "__pd_sinh_2", FIXED(2)},
-        {"__pd_sinh_1", "__pd_sinh_4", FIXED(4)},
-        {"__pd_sinh_1", "__pd_sinh_8", FIXED(8)},
-
-        {"__ps_sinh_1", "__ps_sinh_4", FIXED(4)},
-        {"__ps_sinh_1", "__ps_sinh_8", FIXED(8)},
-        {"__ps_sinh_1", "__ps_sinh_16", FIXED(16)},
-
-        {"__rd_sinh_1", "__rd_sinh_2", FIXED(2)},
-        {"__rd_sinh_1", "__rd_sinh_4", FIXED(4)},
-        {"__rd_sinh_1", "__rd_sinh_8", FIXED(8)},
-
-        {"__rs_sinh_1", "__rs_sinh_4", FIXED(4)},
-        {"__rs_sinh_1", "__rs_sinh_8", FIXED(8)},
-        {"__rs_sinh_1", "__rs_sinh_16", FIXED(16)},
-
-        {"__fd_cosh_1", "__fd_cosh_2", FIXED(2)},
-        {"__fd_cosh_1", "__fd_cosh_4", FIXED(4)},
-        {"__fd_cosh_1", "__fd_cosh_8", FIXED(8)},
-
-        {"__fs_cosh_1", "__fs_cosh_4", FIXED(4)},
-        {"__fs_cosh_1", "__fs_cosh_8", FIXED(8)},
-        {"__fs_cosh_1", "__fs_cosh_16", FIXED(16)},
-
-        {"__pd_cosh_1", "__pd_cosh_2", FIXED(2)},
-        {"__pd_cosh_1", "__pd_cosh_4", FIXED(4)},
-        {"__pd_cosh_1", "__pd_cosh_8", FIXED(8)},
-
-        {"__ps_cosh_1", "__ps_cosh_4", FIXED(4)},
-        {"__ps_cosh_1", "__ps_cosh_8", FIXED(8)},
-        {"__ps_cosh_1", "__ps_cosh_16", FIXED(16)},
-
-        {"__rd_cosh_1", "__rd_cosh_2", FIXED(2)},
-        {"__rd_cosh_1", "__rd_cosh_4", FIXED(4)},
-        {"__rd_cosh_1", "__rd_cosh_8", FIXED(8)},
-
-        {"__rs_cosh_1", "__rs_cosh_4", FIXED(4)},
-        {"__rs_cosh_1", "__rs_cosh_8", FIXED(8)},
-        {"__rs_cosh_1", "__rs_cosh_16", FIXED(16)},
-
-        {"__fd_tanh_1", "__fd_tanh_2", FIXED(2)},
-        {"__fd_tanh_1", "__fd_tanh_4", FIXED(4)},
-        {"__fd_tanh_1", "__fd_tanh_8", FIXED(8)},
-
-        {"__fs_tanh_1", "__fs_tanh_4", FIXED(4)},
-        {"__fs_tanh_1", "__fs_tanh_8", FIXED(8)},
-        {"__fs_tanh_1", "__fs_tanh_16", FIXED(16)},
-
-        {"__pd_tanh_1", "__pd_tanh_2", FIXED(2)},
-        {"__pd_tanh_1", "__pd_tanh_4", FIXED(4)},
-        {"__pd_tanh_1", "__pd_tanh_8", FIXED(8)},
-
-        {"__ps_tanh_1", "__ps_tanh_4", FIXED(4)},
-        {"__ps_tanh_1", "__ps_tanh_8", FIXED(8)},
-        {"__ps_tanh_1", "__ps_tanh_16", FIXED(16)},
-
-        {"__rd_tanh_1", "__rd_tanh_2", FIXED(2)},
-        {"__rd_tanh_1", "__rd_tanh_4", FIXED(4)},
-        {"__rd_tanh_1", "__rd_tanh_8", FIXED(8)},
-
-        {"__rs_tanh_1", "__rs_tanh_4", FIXED(4)},
-        {"__rs_tanh_1", "__rs_tanh_8", FIXED(8)},
-        {"__rs_tanh_1", "__rs_tanh_16", FIXED(16)},
-
-        {"__fd_asin_1", "__fd_asin_2", FIXED(2)},
-        {"__fd_asin_1", "__fd_asin_4", FIXED(4)},
-        {"__fd_asin_1", "__fd_asin_8", FIXED(8)},
-
-        {"__fs_asin_1", "__fs_asin_4", FIXED(4)},
-        {"__fs_asin_1", "__fs_asin_8", FIXED(8)},
-        {"__fs_asin_1", "__fs_asin_16", FIXED(16)},
-
-        {"__pd_asin_1", "__pd_asin_2", FIXED(2)},
-        {"__pd_asin_1", "__pd_asin_4", FIXED(4)},
-        {"__pd_asin_1", "__pd_asin_8", FIXED(8)},
-
-        {"__ps_asin_1", "__ps_asin_4", FIXED(4)},
-        {"__ps_asin_1", "__ps_asin_8", FIXED(8)},
-        {"__ps_asin_1", "__ps_asin_16", FIXED(16)},
-
-        {"__rd_asin_1", "__rd_asin_2", FIXED(2)},
-        {"__rd_asin_1", "__rd_asin_4", FIXED(4)},
-        {"__rd_asin_1", "__rd_asin_8", FIXED(8)},
-
-        {"__rs_asin_1", "__rs_asin_4", FIXED(4)},
-        {"__rs_asin_1", "__rs_asin_8", FIXED(8)},
-        {"__rs_asin_1", "__rs_asin_16", FIXED(16)},
-
-        {"__fd_acos_1", "__fd_acos_2", FIXED(2)},
-        {"__fd_acos_1", "__fd_acos_4", FIXED(4)},
-        {"__fd_acos_1", "__fd_acos_8", FIXED(8)},
-
-        {"__fs_acos_1", "__fs_acos_4", FIXED(4)},
-        {"__fs_acos_1", "__fs_acos_8", FIXED(8)},
-        {"__fs_acos_1", "__fs_acos_16", FIXED(16)},
-
-        {"__pd_acos_1", "__pd_acos_2", FIXED(2)},
-        {"__pd_acos_1", "__pd_acos_4", FIXED(4)},
-        {"__pd_acos_1", "__pd_acos_8", FIXED(8)},
-
-        {"__ps_acos_1", "__ps_acos_4", FIXED(4)},
-        {"__ps_acos_1", "__ps_acos_8", FIXED(8)},
-        {"__ps_acos_1", "__ps_acos_16", FIXED(16)},
-
-        {"__rd_acos_1", "__rd_acos_2", FIXED(2)},
-        {"__rd_acos_1", "__rd_acos_4", FIXED(4)},
-        {"__rd_acos_1", "__rd_acos_8", FIXED(8)},
-
-        {"__rs_acos_1", "__rs_acos_4", FIXED(4)},
-        {"__rs_acos_1", "__rs_acos_8", FIXED(8)},
-        {"__rs_acos_1", "__rs_acos_16", FIXED(16)},
-
-        {"__fd_atan_1", "__fd_atan_2", FIXED(2)},
-        {"__fd_atan_1", "__fd_atan_4", FIXED(4)},
-        {"__fd_atan_1", "__fd_atan_8", FIXED(8)},
-
-        {"__fs_atan_1", "__fs_atan_4", FIXED(4)},
-        {"__fs_atan_1", "__fs_atan_8", FIXED(8)},
-        {"__fs_atan_1", "__fs_atan_16", FIXED(16)},
-
-        {"__pd_atan_1", "__pd_atan_2", FIXED(2)},
-        {"__pd_atan_1", "__pd_atan_4", FIXED(4)},
-        {"__pd_atan_1", "__pd_atan_8", FIXED(8)},
-
-        {"__ps_atan_1", "__ps_atan_4", FIXED(4)},
-        {"__ps_atan_1", "__ps_atan_8", FIXED(8)},
-        {"__ps_atan_1", "__ps_atan_16", FIXED(16)},
-
-        {"__rd_atan_1", "__rd_atan_2", FIXED(2)},
-        {"__rd_atan_1", "__rd_atan_4", FIXED(4)},
-        {"__rd_atan_1", "__rd_atan_8", FIXED(8)},
-
-        {"__rs_atan_1", "__rs_atan_4", FIXED(4)},
-        {"__rs_atan_1", "__rs_atan_8", FIXED(8)},
-        {"__rs_atan_1", "__rs_atan_16", FIXED(16)},
-
-        {"__fd_atan2_1", "__fd_atan2_2", FIXED(2)},
-        {"__fd_atan2_1", "__fd_atan2_4", FIXED(4)},
-        {"__fd_atan2_1", "__fd_atan2_8", FIXED(8)},
-
-        {"__fs_atan2_1", "__fs_atan2_4", FIXED(4)},
-        {"__fs_atan2_1", "__fs_atan2_8", FIXED(8)},
-        {"__fs_atan2_1", "__fs_atan2_16", FIXED(16)},
-
-        {"__pd_atan2_1", "__pd_atan2_2", FIXED(2)},
-        {"__pd_atan2_1", "__pd_atan2_4", FIXED(4)},
-        {"__pd_atan2_1", "__pd_atan2_8", FIXED(8)},
-
-        {"__ps_atan2_1", "__ps_atan2_4", FIXED(4)},
-        {"__ps_atan2_1", "__ps_atan2_8", FIXED(8)},
-        {"__ps_atan2_1", "__ps_atan2_16", FIXED(16)},
-
-        {"__rd_atan2_1", "__rd_atan2_2", FIXED(2)},
-        {"__rd_atan2_1", "__rd_atan2_4", FIXED(4)},
-        {"__rd_atan2_1", "__rd_atan2_8", FIXED(8)},
-
-        {"__rs_atan2_1", "__rs_atan2_4", FIXED(4)},
-        {"__rs_atan2_1", "__rs_atan2_8", FIXED(8)},
-        {"__rs_atan2_1", "__rs_atan2_16", FIXED(16)},
-
-        {"__fd_pow_1", "__fd_pow_2", FIXED(2)},
-        {"__fd_pow_1", "__fd_pow_4", FIXED(4)},
-        {"__fd_pow_1", "__fd_pow_8", FIXED(8)},
-
-        {"__fs_pow_1", "__fs_pow_4", FIXED(4)},
-        {"__fs_pow_1", "__fs_pow_8", FIXED(8)},
-        {"__fs_pow_1", "__fs_pow_16", FIXED(16)},
-
-        {"__pd_pow_1", "__pd_pow_2", FIXED(2)},
-        {"__pd_pow_1", "__pd_pow_4", FIXED(4)},
-        {"__pd_pow_1", "__pd_pow_8", FIXED(8)},
-
-        {"__ps_pow_1", "__ps_pow_4", FIXED(4)},
-        {"__ps_pow_1", "__ps_pow_8", FIXED(8)},
-        {"__ps_pow_1", "__ps_pow_16", FIXED(16)},
-
-        {"__rd_pow_1", "__rd_pow_2", FIXED(2)},
-        {"__rd_pow_1", "__rd_pow_4", FIXED(4)},
-        {"__rd_pow_1", "__rd_pow_8", FIXED(8)},
-
-        {"__rs_pow_1", "__rs_pow_4", FIXED(4)},
-        {"__rs_pow_1", "__rs_pow_8", FIXED(8)},
-        {"__rs_pow_1", "__rs_pow_16", FIXED(16)},
-
-        {"__fs_powi_1", "__fs_powi_4", FIXED(4)},
-        {"__fs_powi_1", "__fs_powi_8", FIXED(8)},
-        {"__fs_powi_1", "__fs_powi_16", FIXED(16)},
-
-        {"__ps_powi_1", "__ps_powi_4", FIXED(4)},
-        {"__ps_powi_1", "__ps_powi_8", FIXED(8)},
-        {"__ps_powi_1", "__ps_powi_16", FIXED(16)},
-
-        {"__rs_powi_1", "__rs_powi_4", FIXED(4)},
-        {"__rs_powi_1", "__rs_powi_8", FIXED(8)},
-        {"__rs_powi_1", "__rs_powi_16", FIXED(16)},
-
-        {"__fd_powi1_1", "__fd_powi1_2", FIXED(2)},
-        {"__fd_powi1_1", "__fd_powi1_4", FIXED(4)},
-        {"__fd_powi1_1", "__fd_powi1_8", FIXED(8)},
-
-        {"__fs_powi1_1", "__fs_powi1_4", FIXED(4)},
-        {"__fs_powi1_1", "__fs_powi1_8", FIXED(8)},
-        {"__fs_powi1_1", "__fs_powi1_16", FIXED(16)},
-
-        {"__pd_powi1_1", "__pd_powi1_2", FIXED(2)},
-        {"__pd_powi1_1", "__pd_powi1_4", FIXED(4)},
-        {"__pd_powi1_1", "__pd_powi1_8", FIXED(8)},
-
-        {"__ps_powi1_1", "__ps_powi1_4", FIXED(4)},
-        {"__ps_powi1_1", "__ps_powi1_8", FIXED(8)},
-        {"__ps_powi1_1", "__ps_powi1_16", FIXED(16)},
-
-        {"__rd_powi1_1", "__rd_powi1_2", FIXED(2)},
-        {"__rd_powi1_1", "__rd_powi1_4", FIXED(4)},
-        {"__rd_powi1_1", "__rd_powi1_8", FIXED(8)},
-
-        {"__rs_powi1_1", "__rs_powi1_4", FIXED(4)},
-        {"__rs_powi1_1", "__rs_powi1_8", FIXED(8)},
-        {"__rs_powi1_1", "__rs_powi1_16", FIXED(16)},
-
-        {"__fd_powk_1", "__fd_powk_2", FIXED(2)},
-        {"__fd_powk_1", "__fd_powk_4", FIXED(4)},
-        {"__fd_powk_1", "__fd_powk_8", FIXED(8)},
-
-        {"__fs_powk_1", "__fs_powk_4", FIXED(4)},
-        {"__fs_powk_1", "__fs_powk_8", FIXED(8)},
-        {"__fs_powk_1", "__fs_powk_16", FIXED(16)},
-
-        {"__pd_powk_1", "__pd_powk_2", FIXED(2)},
-        {"__pd_powk_1", "__pd_powk_4", FIXED(4)},
-        {"__pd_powk_1", "__pd_powk_8", FIXED(8)},
-
-        {"__ps_powk_1", "__ps_powk_4", FIXED(4)},
-        {"__ps_powk_1", "__ps_powk_8", FIXED(8)},
-        {"__ps_powk_1", "__ps_powk_16", FIXED(16)},
-
-        {"__rd_powk_1", "__rd_powk_2", FIXED(2)},
-        {"__rd_powk_1", "__rd_powk_4", FIXED(4)},
-        {"__rd_powk_1", "__rd_powk_8", FIXED(8)},
-
-        {"__rs_powk_1", "__rs_powk_4", FIXED(4)},
-        {"__rs_powk_1", "__rs_powk_8", FIXED(8)},
-        {"__rs_powk_1", "__rs_powk_16", FIXED(16)},
-
-        {"__fd_powk1_1", "__fd_powk1_2", FIXED(2)},
-        {"__fd_powk1_1", "__fd_powk1_4", FIXED(4)},
-        {"__fd_powk1_1", "__fd_powk1_8", FIXED(8)},
-
-        {"__fs_powk1_1", "__fs_powk1_4", FIXED(4)},
-        {"__fs_powk1_1", "__fs_powk1_8", FIXED(8)},
-        {"__fs_powk1_1", "__fs_powk1_16", FIXED(16)},
-
-        {"__pd_powk1_1", "__pd_powk1_2", FIXED(2)},
-        {"__pd_powk1_1", "__pd_powk1_4", FIXED(4)},
-        {"__pd_powk1_1", "__pd_powk1_8", FIXED(8)},
-
-        {"__ps_powk1_1", "__ps_powk1_4", FIXED(4)},
-        {"__ps_powk1_1", "__ps_powk1_8", FIXED(8)},
-        {"__ps_powk1_1", "__ps_powk1_16", FIXED(16)},
-
-        {"__rd_powk1_1", "__rd_powk1_2", FIXED(2)},
-        {"__rd_powk1_1", "__rd_powk1_4", FIXED(4)},
-        {"__rd_powk1_1", "__rd_powk1_8", FIXED(8)},
-
-        {"__rs_powk1_1", "__rs_powk1_4", FIXED(4)},
-        {"__rs_powk1_1", "__rs_powk1_8", FIXED(8)},
-        {"__rs_powk1_1", "__rs_powk1_16", FIXED(16)},
-
-        {"__fd_log10_1", "__fd_log10_2", FIXED(2)},
-        {"__fd_log10_1", "__fd_log10_4", FIXED(4)},
-        {"__fd_log10_1", "__fd_log10_8", FIXED(8)},
-
-        {"__fs_log10_1", "__fs_log10_4", FIXED(4)},
-        {"__fs_log10_1", "__fs_log10_8", FIXED(8)},
-        {"__fs_log10_1", "__fs_log10_16", FIXED(16)},
-
-        {"__pd_log10_1", "__pd_log10_2", FIXED(2)},
-        {"__pd_log10_1", "__pd_log10_4", FIXED(4)},
-        {"__pd_log10_1", "__pd_log10_8", FIXED(8)},
-
-        {"__ps_log10_1", "__ps_log10_4", FIXED(4)},
-        {"__ps_log10_1", "__ps_log10_8", FIXED(8)},
-        {"__ps_log10_1", "__ps_log10_16", FIXED(16)},
-
-        {"__rd_log10_1", "__rd_log10_2", FIXED(2)},
-        {"__rd_log10_1", "__rd_log10_4", FIXED(4)},
-        {"__rd_log10_1", "__rd_log10_8", FIXED(8)},
-
-        {"__rs_log10_1", "__rs_log10_4", FIXED(4)},
-        {"__rs_log10_1", "__rs_log10_8", FIXED(8)},
-        {"__rs_log10_1", "__rs_log10_16", FIXED(16)},
-
-        {"__fd_log_1", "__fd_log_2", FIXED(2)},
-        {"__fd_log_1", "__fd_log_4", FIXED(4)},
-        {"__fd_log_1", "__fd_log_8", FIXED(8)},
-
-        {"__fs_log_1", "__fs_log_4", FIXED(4)},
-        {"__fs_log_1", "__fs_log_8", FIXED(8)},
-        {"__fs_log_1", "__fs_log_16", FIXED(16)},
-
-        {"__pd_log_1", "__pd_log_2", FIXED(2)},
-        {"__pd_log_1", "__pd_log_4", FIXED(4)},
-        {"__pd_log_1", "__pd_log_8", FIXED(8)},
-
-        {"__ps_log_1", "__ps_log_4", FIXED(4)},
-        {"__ps_log_1", "__ps_log_8", FIXED(8)},
-        {"__ps_log_1", "__ps_log_16", FIXED(16)},
-
-        {"__rd_log_1", "__rd_log_2", FIXED(2)},
-        {"__rd_log_1", "__rd_log_4", FIXED(4)},
-        {"__rd_log_1", "__rd_log_8", FIXED(8)},
-
-        {"__rs_log_1", "__rs_log_4", FIXED(4)},
-        {"__rs_log_1", "__rs_log_8", FIXED(8)},
-        {"__rs_log_1", "__rs_log_16", FIXED(16)},
-
-        {"__fs_exp_1", "__fs_exp_4", FIXED(4)},
-        {"__fs_exp_1", "__fs_exp_8", FIXED(8)},
-        {"__fs_exp_1", "__fs_exp_16", FIXED(16)},
-
-        {"__pd_exp_1", "__pd_exp_2", FIXED(2)},
-        {"__pd_exp_1", "__pd_exp_4", FIXED(4)},
-        {"__pd_exp_1", "__pd_exp_8", FIXED(8)},
-
-        {"__ps_exp_1", "__ps_exp_4", FIXED(4)},
-        {"__ps_exp_1", "__ps_exp_8", FIXED(8)},
-        {"__ps_exp_1", "__ps_exp_16", FIXED(16)},
-
-        {"__rd_exp_1", "__rd_exp_2", FIXED(2)},
-        {"__rd_exp_1", "__rd_exp_4", FIXED(4)},
-        {"__rd_exp_1", "__rd_exp_8", FIXED(8)},
-
-        {"__rs_exp_1", "__rs_exp_4", FIXED(4)},
-        {"__rs_exp_1", "__rs_exp_8", FIXED(8)},
-        {"__rs_exp_1", "__rs_exp_16", FIXED(16)}
-    };
-    addVectorizableFunctions(VecFuncs);
+    if (T.getArch() == Triple::aarch64) {
+      const VecDesc VecFuncs[] = {
+      #define TLI_DEFINE_PGMATH_AARCH64_VECFUNCS
+      #include "llvm/Analysis/VecFuncs.def"
+      };
+      addVectorizableFunctions(VecFuncs);
+    } else if (T.getArch() == Triple::x86_64) {
+      const VecDesc VecFuncs[] = {
+      #define TLI_DEFINE_PGMATH_X86_VECFUNCS
+      #include "llvm/Analysis/VecFuncs.def"
+      };
+      addVectorizableFunctions(VecFuncs);
+    }
     break;
   }
 


### PR DESCRIPTION
This patch fixes link-time issues experienced while compiling some
more obscure Fortran workloads. For those programs, calls to the
libpgmath functions not defined for AArch64 were generated, e.g.
`__pg_log_4` or `__fd_log_4`. This patch eliminates such possibility.
