### PR TITLE
Delete pgmath veclib definitions for sincos

### DIFF
--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -1735,30 +1735,6 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
         {"__rs_cos_1", "__rs_cos_8", FIXED(8)},
         {"__rs_cos_1", "__rs_cos_16", FIXED(16)},
 
-        {"__fd_sincos_1", "__fd_sincos_2", FIXED(2)},
-        {"__fd_sincos_1", "__fd_sincos_4", FIXED(4)},
-        {"__fd_sincos_1", "__fd_sincos_8", FIXED(8)},
-
-        {"__fs_sincos_1", "__fs_sincos_4", FIXED(4)},
-        {"__fs_sincos_1", "__fs_sincos_8", FIXED(8)},
-        {"__fs_sincos_1", "__fs_sincos_16", FIXED(16)},
-
-        {"__pd_sincos_1", "__pd_sincos_2", FIXED(2)},
-        {"__pd_sincos_1", "__pd_sincos_4", FIXED(4)},
-        {"__pd_sincos_1", "__pd_sincos_8", FIXED(8)},
-
-        {"__ps_sincos_1", "__ps_sincos_4", FIXED(4)},
-        {"__ps_sincos_1", "__ps_sincos_8", FIXED(8)},
-        {"__ps_sincos_1", "__ps_sincos_16", FIXED(16)},
-
-        {"__rd_sincos_1", "__rd_sincos_2", FIXED(2)},
-        {"__rd_sincos_1", "__rd_sincos_4", FIXED(4)},
-        {"__rd_sincos_1", "__rd_sincos_8", FIXED(8)},
-
-        {"__rs_sincos_1", "__rs_sincos_4", FIXED(4)},
-        {"__rs_sincos_1", "__rs_sincos_8", FIXED(8)},
-        {"__rs_sincos_1", "__rs_sincos_16", FIXED(16)},
-
         {"__fd_tan_1", "__fd_tan_2", FIXED(2)},
         {"__fd_tan_1", "__fd_tan_4", FIXED(4)},
         {"__fd_tan_1", "__fd_tan_8", FIXED(8)},


### PR DESCRIPTION
As noted in https://github.com/flang-compiler/classic-flang-llvm-project/issues/11,
flang currently crashes when encountering a sincos reference into pgmath.
The issue is is that __fd_sincos_1 is defined as returning a `<{ double, double }>`
struct and there is no LLVM support for automatically vectorizing target
functions of this form. In particular, it is somewhat ambiguous how
to vectorize such function, i.e. how they pack their return values into
the vector registers. `libpgmath` itself also has a somewhat questionable
implementation of the vector forms of `sincos`, relying on this beatuty:
https://github.com/flang-compiler/flang/blob/master/runtime/libpgmath/lib/common/mth_vreturns.c#L8-L47

This may sometimes work in practice, but it is not particularly robust.
For example, this will definitely break in any sort of LTO or
instrumentation setting.

I think until libpgmath is updated and LLVM upstream has a consensus on how
to vectorize these function, we just need to drop trying to vectorize these
functions. As noted, since LLVM was crashing anyway, no performance and
functionality is lost here over current master.

Fixes https://github.com/flang-compiler/classic-flang-llvm-project/issues/11