### PR TITLE
Delete pgmath veclib definitions for sincos for release14

### DIFF
--- a/llvm/include/llvm/Analysis/VecFuncs.def
+++ b/llvm/include/llvm/Analysis/VecFuncs.def
@@ -487,6 +487,15 @@ TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_4", FIXED(4))
 TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_2", FIXED(2))
 TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_4", FIXED(4))
 
+TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_4", FIXED(4))
+
+TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_2", FIXED(2))
+TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_4", FIXED(4))
+
 TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_2", FIXED(2))
 TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_4", FIXED(4))
 

--- a/llvm/include/llvm/Analysis/VecFuncs.def
+++ b/llvm/include/llvm/Analysis/VecFuncs.def
@@ -487,15 +487,6 @@ TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_4", FIXED(4))
 TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_2", FIXED(2))
 TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_4", FIXED(4))
 
-TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_2", FIXED(2))
-TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_4", FIXED(4))
-
-TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_2", FIXED(2))
-TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_4", FIXED(4))
-
-TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_2", FIXED(2))
-TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_4", FIXED(4))
-
 TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_2", FIXED(2))
 TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_4", FIXED(4))
 
@@ -687,30 +678,6 @@ TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_8", FIXED(8))
 TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_4", FIXED(4))
 TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_8", FIXED(8))
 TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_16", FIXED(16))
-
-TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_2", FIXED(2))
-TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_4", FIXED(4))
-TLI_DEFINE_VECFUNC("__fd_sincos_1", "__fd_sincos_8", FIXED(8))
-
-TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_4", FIXED(4))
-TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_8", FIXED(8))
-TLI_DEFINE_VECFUNC("__fs_sincos_1", "__fs_sincos_16", FIXED(16))
-
-TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_2", FIXED(2))
-TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_4", FIXED(4))
-TLI_DEFINE_VECFUNC("__pd_sincos_1", "__pd_sincos_8", FIXED(8))
-
-TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_4", FIXED(4))
-TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_8", FIXED(8))
-TLI_DEFINE_VECFUNC("__ps_sincos_1", "__ps_sincos_16", FIXED(16))
-
-TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_2", FIXED(2))
-TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_4", FIXED(4))
-TLI_DEFINE_VECFUNC("__rd_sincos_1", "__rd_sincos_8", FIXED(8))
-
-TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_4", FIXED(4))
-TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_8", FIXED(8))
-TLI_DEFINE_VECFUNC("__rs_sincos_1", "__rs_sincos_16", FIXED(16))
 
 TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_2", FIXED(2))
 TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_4", FIXED(4))


### PR DESCRIPTION
Rebase of #132 on release_14x. I also deleted the aarch64 functions, but I haven't tested if they caused problems like the x86 ones. A rough guess would be that they also do, because pgmath does that weird vector thing.

@Keno 