### PR TITLE
[workflows] GitHub CI should build with assertions enabled

### DIFF
--- a/.github/workflows/Ubuntu20Dockerfile
+++ b/.github/workflows/Ubuntu20Dockerfile
@@ -57,7 +57,7 @@ RUN if [ "$INITIAL_BUILD" != "true" ]; then \
     mkdir /home/root && cd home/root && \
     git clone --depth 1 --single-branch --branch $BRANCH_NAME https://github.com/flang-compiler/classic-flang-llvm-project.git classic-flang-llvm-project && \
     cd classic-flang-llvm-project && \
-    ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i -v; \
+    ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i -x "-DLLVM_ENABLE_ASSERTIONS=ON" -v; \
     fi
 
 RUN useradd github && \

--- a/.github/workflows/flang-arm64-tests.yml
+++ b/.github/workflows/flang-arm64-tests.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Copy llvm-lit
         run: |
           cd ${{ env.build_path }}/flang
-          cp ${{ env.build_path }}/classic-flang-llvm-project/build/bin/llvm-lit build/bin/.
+          cp ${{ env.build_path }}/classic-flang-llvm-project/build/bin/llvm-lit build/flang/bin/
 
       - name: Test flang
         run: |
-          cd ${{ env.build_path }}/flang/build
+          cd ${{ env.build_path }}/flang/build/flang
           make check-all

--- a/.github/workflows/flang-arm64-tests.yml
+++ b/.github/workflows/flang-arm64-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and install llvm
         run: |
           cd ${{ env.build_path }}/classic-flang-llvm-project
-          ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -i -v
+          ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -i -x "-DLLVM_ENABLE_ASSERTIONS=ON" -v
 
       - name: Checkout flang
         run: |

--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -58,7 +58,7 @@ jobs:
           ${{ matrix.cpp }}-${{ matrix.version }} --version
 
       - name: Build and install llvm
-        run: ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -c -i -s -v
+        run: ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -c -i -s -x "-DLLVM_ENABLE_ASSERTIONS=ON" -v
 
       - name: Checkout flang
         run: |

--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -73,9 +73,9 @@ jobs:
       - name: Copy llvm-lit
         run: |
           cd ../../flang
-          cp ../classic-flang-llvm-project/classic-flang-llvm-project/build/bin/llvm-lit build/bin/.
+          cp ../classic-flang-llvm-project/classic-flang-llvm-project/build/bin/llvm-lit build/flang/bin/
 
       - name: Test flang
         run: |
-          cd ../../flang/build
+          cd ../../flang/build/flang
           make check-all

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -81,12 +81,12 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         run: |
-          ./build-llvm-project.sh -t X86 -e "clang" -p /usr/local -s -n $(sysctl -n hw.logicalcpu) -i -v
+          ./build-llvm-project.sh -t X86 -e "clang" -p /usr/local -s -n $(sysctl -n hw.logicalcpu) -i -x "-DLLVM_ENABLE_ASSERTIONS=ON" -v
           cd build
           make check-all
       - name: Test clang ubuntu
         if: ${{ matrix.os == 'ubuntu-latest'}}
         run: |
-          ./build-llvm-project.sh -t X86 -e "${{ inputs.projects }}" -p /usr/local -s -n $(nproc) -i -v
+          ./build-llvm-project.sh -t X86 -e "${{ inputs.projects }}" -p /usr/local -s -n $(nproc) -i -x "-DLLVM_ENABLE_ASSERTIONS=ON" -v
           cd build
           make check-all

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -67,6 +67,7 @@ jobs:
             -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} \
             -b /usr/bin/${{env.cpp}}-${{ matrix.version }} \
             -n $(nproc) \
+            -x "-DLLVM_ENABLE_ASSERTIONS=ON" \
             -v
           # Archive the source + build directories for future installation
           cd ..

--- a/build-llvm-project.sh
+++ b/build-llvm-project.sh
@@ -11,6 +11,7 @@ USE_SUDO="0"
 C_COMPILER_PATH="/usr/bin/gcc"
 CXX_COMPILER_PATH="/usr/bin/g++"
 LLVM_ENABLE_PROJECTS="clang;openmp"
+EXTRA_CMAKE_OPTS=""
 VERBOSE=""
 
 set -e # Exit script on first error.
@@ -37,21 +38,24 @@ function print_usage {
     echo "  -a  C compiler path. Default: /usr/bin/gcc";
     echo "  -b  C++ compiler path. Default: /usr/bin/g++";
     echo "  -e  List of the LLVM sub-projects to build. Default: clang;openmp";
+    echo "  -x  Extra CMake options. Default: ''";
     echo "  -v  Enable verbose output";
 }
-while getopts "t:d:p:n:c?i?s?a:b:e:v" opt; do
+
+while getopts "t:d:p:n:cisa:b:e:x:v?" opt; do
     case "$opt" in
-        t)  TARGET=$OPTARG;;
-        d)  BUILD_TYPE=$OPTARG;;
-        p)  INSTALL_PREFIX=$OPTARG;;
-        n)  NPROC=$OPTARG;;
-        c)  USE_CCACHE="1";;
-        i)  DO_INSTALL="1";;
-        s)  USE_SUDO="1";;
-        a)  C_COMPILER_PATH=$OPTARG;;
-        b)  CXX_COMPILER_PATH=$OPTARG;;
-        e)  LLVM_ENABLE_PROJECTS=$OPTARG;;
-        v)  VERBOSE="1";;
+        t) TARGET=$OPTARG;;
+        d) BUILD_TYPE=$OPTARG;;
+        p) INSTALL_PREFIX=$OPTARG;;
+        n) NPROC=$OPTARG;;
+        c) USE_CCACHE="1";;
+        i) DO_INSTALL="1";;
+        s) USE_SUDO="1";;
+        a) C_COMPILER_PATH=$OPTARG;;
+        b) CXX_COMPILER_PATH=$OPTARG;;
+        e) LLVM_ENABLE_PROJECTS=$OPTARG;;
+        x) EXTRA_CMAKE_OPTS="$OPTARG";;
+        v) VERBOSE="1";;
         ?) print_usage; exit 0;;
     esac
 done
@@ -71,6 +75,10 @@ if [ $USE_CCACHE == "1" ]; then
   CMAKE_OPTIONS="$CMAKE_OPTIONS \
       -DCMAKE_C_COMPILER_LAUNCHER=ccache \
       -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+fi
+
+if [ -n "$EXTRA_CMAKE_OPTS" ]; then
+  CMAKE_OPTIONS="$CMAKE_OPTIONS $EXTRA_CMAKE_OPTS"
 fi
 
 # Build and install


### PR DESCRIPTION
This PR adds two commits to enable the CI to build LLVM with assertions enabled.

A third commit is included to update the Flang build directory, to avoid CI failures due to https://github.com/flang-compiler/flang/commit/054bde36125cfd1d15581fec6eaaac79e63213bb.