### PR TITLE
Various GitHub CI updates (release_13x)

### DIFF
--- a/.github/workflows/Ubuntu20Dockerfile
+++ b/.github/workflows/Ubuntu20Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get install -y software-properties-common && \
     apt-get install -f -y llvm-10 clang-10 && \
     apt-get install -f -y llvm-11 clang-11
 
-# Install the tools for release_13x
+# Install the tools for release_13x and newer
 RUN apt --fix-missing update && \
     apt install -y build-essential manpages-dev \
     libssl-dev zlib1g-dev \
@@ -51,10 +51,11 @@ RUN ln -s /usr/bin/ninja-build /usr/local/bin/ninja
 
 RUN mkdir /home/github/
 
+ARG BRANCH_NAME
 RUN mkdir /home/root && cd home/root && \
-    git clone --depth 1 --single-branch --branch release_13x https://github.com/flang-compiler/classic-flang-llvm-project.git classic-flang-llvm-project && \
+    git clone --depth 1 --single-branch --branch $BRANCH_NAME https://github.com/flang-compiler/classic-flang-llvm-project.git classic-flang-llvm-project && \
     cd classic-flang-llvm-project && \
-    ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i
+    ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i -v
 
 RUN useradd github && \
     chown -R github:github /home/github

--- a/.github/workflows/Ubuntu20Dockerfile
+++ b/.github/workflows/Ubuntu20Dockerfile
@@ -55,7 +55,7 @@ ARG BRANCH_NAME
 RUN mkdir /home/root && cd home/root && \
     git clone --depth 1 --single-branch --branch $BRANCH_NAME https://github.com/flang-compiler/classic-flang-llvm-project.git classic-flang-llvm-project && \
     cd classic-flang-llvm-project && \
-    ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i -v
+    ./build-llvm-project.sh -t AArch64 -d RelWithDebInfo -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i -v
 
 RUN useradd github && \
     chown -R github:github /home/github

--- a/.github/workflows/build_push_docker_image_Ubuntu20.yml
+++ b/.github/workflows/build_push_docker_image_Ubuntu20.yml
@@ -47,6 +47,8 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           tags: ghcr.io/${{ github.repository_owner }}/ubuntu20-flang-${{ steps.extract_branch.outputs.branch }}:latest
           platforms: linux/arm64
+          build-args: |
+            BRANCH_NAME=${{ steps.extract_branch.outputs.branch }}
 
       # This ugly bit is necessary if you don't want your cache to grow forever
       # till it hits GitHub's limit of 5GB.

--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -35,6 +35,11 @@ jobs:
       uses: llvm/actions/setup-windows@main
       with:
         arch: amd64
+    - name: Free disk space (Ubuntu)
+      if: startsWith(matrix.os, 'ubuntu')
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
     - uses: actions/checkout@v1
@@ -48,12 +53,12 @@ jobs:
       if: ${{ matrix.os == 'macOS-latest'}}
       run: |
         nproc="sysctl -n hw.logicalcpu"
-        ./build-llvm-project.sh -t X86 -e "clang" -p /usr/local -s -n `$nproc` -i -v
+        ./build-llvm-project.sh -t X86 -d RelWithDebInfo -e "clang" -p /usr/local -s -n `$nproc` -i -v
         cd build
         make check-all
     - name: Test clang ubuntu
       if: ${{ matrix.os == 'ubuntu-latest'}}
       run: |
-        ./build-llvm-project.sh -t X86 -p /usr/local -s -n $(nproc) -i -v
+        ./build-llvm-project.sh -t X86 -d RelWithDebInfo -p /usr/local -s -n $(nproc) -i -v
         cd build
         make check-all

--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -3,12 +3,14 @@ name: Clang Tests
 on:
   push:
     branches:
-      - 'release/**'
+      - 'release_*x'
     paths:
       - 'clang/**'
       - 'llvm/**'
       - '.github/workflows/clang-tests.yml'
   pull_request:
+    branches:
+      - 'release_*x'
     paths:
       - 'clang/**'
       - 'llvm/**'

--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -46,12 +46,12 @@ jobs:
       if: ${{ matrix.os == 'macOS-latest'}}
       run: |
         nproc="sysctl -n hw.logicalcpu"
-        ./build-llvm-project.sh -t X86 -e "clang" -p /usr/local -s -n `$nproc` -i
+        ./build-llvm-project.sh -t X86 -e "clang" -p /usr/local -s -n `$nproc` -i -v
         cd build
         make check-all
     - name: Test clang ubuntu
       if: ${{ matrix.os == 'ubuntu-latest'}}
       run: |
-        ./build-llvm-project.sh -t X86 -p /usr/local -s -n $(nproc) -i
+        ./build-llvm-project.sh -t X86 -p /usr/local -s -n $(nproc) -i -v
         cd build
         make check-all

--- a/.github/workflows/flang-arm64-tests.yml
+++ b/.github/workflows/flang-arm64-tests.yml
@@ -1,0 +1,70 @@
+name: Build and test Flang
+
+on:
+  pull_request:
+    branches:
+      - 'release_*x'
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      build_path: /home/github
+      install_prefix: /home/github/usr/local
+    container:
+      image: ghcr.io/${{ github.repository_owner}}/ubuntu20-flang-${{ github.base_ref }}:latest
+      credentials:
+        username: github
+    strategy:
+      matrix:
+        target: [AArch64]
+        cc: [clang]
+        cpp: [clang++]
+        version: [10, 11]
+        include:
+          - target: AArch64
+            cc: gcc
+            cpp: g++
+            version: 10
+
+    steps:
+      - name: Check tools
+        run: |
+          git --version
+          cmake --version
+          make --version
+          ${{ matrix.cc }}-${{ matrix.version }} --version
+          ${{ matrix.cpp }}-${{ matrix.version }} --version
+
+      - name: Manual checkout to build in user's home dir (pull_request)
+        run: |
+          cd ${{ env.build_path }}
+          git clone https://github.com/flang-compiler/classic-flang-llvm-project.git
+          cd classic-flang-llvm-project
+          git fetch origin ${{github.ref}}:pr_branch
+          git checkout pr_branch
+
+      - name: Build and install llvm
+        run: |
+          cd ${{ env.build_path }}/classic-flang-llvm-project
+          ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -i -v
+
+      - name: Checkout flang
+        run: |
+          cd ${{ env.build_path }}
+          git clone --depth 1 --single-branch --branch master https://github.com/flang-compiler/flang.git
+
+      - name: Build and install libpgmath & flang
+        run: |
+          cd ${{ env.build_path }}/flang
+          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc)
+
+      - name: Copy llvm-lit
+        run: |
+          cd ${{ env.build_path }}/flang
+          cp ${{ env.build_path }}/classic-flang-llvm-project/build/bin/llvm-lit build/bin/.
+
+      - name: Test flang
+        run: |
+          cd ${{ env.build_path }}/flang/build
+          make check-all

--- a/.github/workflows/flang-arm64-tests.yml
+++ b/.github/workflows/flang-arm64-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and install llvm
         run: |
           cd ${{ env.build_path }}/classic-flang-llvm-project
-          ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -i -v
+          ./build-llvm-project.sh -t ${{ matrix.target }} -d RelWithDebInfo -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -i -v
 
       - name: Checkout flang
         run: |
@@ -57,7 +57,7 @@ jobs:
       - name: Build and install libpgmath & flang
         run: |
           cd ${{ env.build_path }}/flang
-          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc)
+          ./build-flang.sh -t ${{ matrix.target }} -d RelWithDebInfo -p ${{ env.install_prefix }} -n $(nproc)
 
       - name: Copy llvm-lit
         run: |

--- a/.github/workflows/flang-arm64-tests.yml
+++ b/.github/workflows/flang-arm64-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout flang
         run: |
           cd ${{ env.build_path }}
-          git clone --depth 1 --single-branch --branch master https://github.com/flang-compiler/flang.git
+          git clone --depth 1 --single-branch --branch legacy https://github.com/flang-compiler/flang.git
 
       - name: Build and install libpgmath & flang
         run: |

--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -57,7 +57,7 @@ jobs:
           ${{ matrix.cpp }}-${{ matrix.version }} --version
 
       - name: Build and install llvm
-        run: ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -c -i -s
+        run: ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -c -i -s -v
 
       - name: Checkout flang
         run: |

--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -2,7 +2,8 @@ name: Build and test Flang
 
 on:
   pull_request:
-    branches: [ release_11x, release_12x, release_13x ]
+    branches:
+      - 'release_*x'
 
 jobs:
   build:

--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout flang
         run: |
           cd ../..
-          git clone --depth 1 --single-branch --branch master https://github.com/flang-compiler/flang.git
+          git clone --depth 1 --single-branch --branch legacy https://github.com/flang-compiler/flang.git
 
       - name: Build and install libpgmath & flang
         run: |

--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -23,6 +23,11 @@ jobs:
             version: 10
 
     steps:
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - uses: actions/checkout@v2
 
       - if: matrix.cc == 'clang'
@@ -58,7 +63,7 @@ jobs:
           ${{ matrix.cpp }}-${{ matrix.version }} --version
 
       - name: Build and install llvm
-        run: ./build-llvm-project.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -c -i -s -v
+        run: ./build-llvm-project.sh -t ${{ matrix.target }} -d RelWithDebInfo -p ${{ env.install_prefix }} -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} -n $(nproc) -c -i -s -v
 
       - name: Checkout flang
         run: |
@@ -68,7 +73,7 @@ jobs:
       - name: Build and install libpgmath & flang
         run: |
           cd ../../flang
-          ./build-flang.sh -t ${{ matrix.target }} -p ${{ env.install_prefix }} -n $(nproc) -c -s
+          ./build-flang.sh -t ${{ matrix.target }} -d RelWithDebInfo -p ${{ env.install_prefix }} -n $(nproc) -c -s
 
       - name: Copy llvm-lit
         run: |

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -30,6 +30,11 @@ jobs:
       uses: llvm/actions/setup-windows@main
       with:
         arch: amd64
+    - name: Free disk space (Ubuntu)
+      if: startsWith(matrix.os, 'ubuntu')
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
     - uses: actions/checkout@v1
@@ -39,12 +44,12 @@ jobs:
       if: ${{ matrix.os == 'macOS-latest'}}
       run: |
         nproc="sysctl -n hw.logicalcpu"
-        ./build-llvm-project.sh -t X86 -e "clang" -p /usr/local -s -n `$nproc` -i -v
+        ./build-llvm-project.sh -t X86 -d RelWithDebInfo -e "clang" -p /usr/local -s -n `$nproc` -i -v
         cd build
         make check-all
     - name: Test llvm ubuntu
       if: ${{ matrix.os == 'ubuntu-latest'}}
       run: |
-        ./build-llvm-project.sh -t X86 -p /usr/local -s -n $(nproc) -i -v
+        ./build-llvm-project.sh -t X86 -d RelWithDebInfo -p /usr/local -s -n $(nproc) -i -v
         cd build
         make check-all

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -37,12 +37,12 @@ jobs:
       if: ${{ matrix.os == 'macOS-latest'}}
       run: |
         nproc="sysctl -n hw.logicalcpu"
-        ./build-llvm-project.sh -t X86 -e "clang" -p /usr/local -s -n `$nproc` -i
+        ./build-llvm-project.sh -t X86 -e "clang" -p /usr/local -s -n `$nproc` -i -v
         cd build
         make check-all
     - name: Test llvm ubuntu
       if: ${{ matrix.os == 'ubuntu-latest'}}
       run: |
-        ./build-llvm-project.sh -t X86 -p /usr/local -s -n $(nproc) -i
+        ./build-llvm-project.sh -t X86 -p /usr/local -s -n $(nproc) -i -v
         cd build
         make check-all

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -3,11 +3,13 @@ name: LLVM Tests
 on:
   push:
     branches:
-      - 'release/**'
+      - 'release_*x'
     paths:
       - 'llvm/**'
       - '.github/workflows/llvm-tests.yml'
   pull_request:
+    branches:
+      - 'release_*x'
     paths:
       - 'llvm/**'
       - '.github/workflows/llvm-tests.yml'

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -16,6 +16,11 @@ jobs:
         version: [10, 11]
             
     steps:
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - if: matrix.cc == 'clang'
         run: |
           echo "cpp=clang++" >> $GITHUB_ENV
@@ -62,6 +67,7 @@ jobs:
           mkdir classic-flang-llvm-project
           ./build-llvm-project.sh \
             -t ${{ matrix.target }} \
+            -d RelWithDebInfo \
             -p /usr/local \
             -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} \
             -b /usr/bin/${{env.cpp}}-${{ matrix.version }} \

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -64,7 +64,8 @@ jobs:
             -p /usr/local \
             -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} \
             -b /usr/bin/${{env.cpp}}-${{ matrix.version }} \
-            -n $(nproc)
+            -n $(nproc) \
+            -v
           # Archive the source + build directories for future installation
           cd ..
           tar -zcf llvm_build.tar.gz classic-flang-llvm-project

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -3,7 +3,8 @@ name: Pre-compile llvm
 on:
   workflow_dispatch:
   push:
-    branches: [ release_100, release_11x, release_12x, release_13x ]
+    branches:
+      - 'release_*x'
 
 jobs:
   build:

--- a/build-llvm-project.sh
+++ b/build-llvm-project.sh
@@ -11,6 +11,7 @@ USE_SUDO="0"
 C_COMPILER_PATH="/usr/bin/gcc"
 CXX_COMPILER_PATH="/usr/bin/g++"
 LLVM_ENABLE_PROJECTS="clang;openmp"
+VERBOSE=""
 
 set -e # Exit script on first error.
 
@@ -36,8 +37,9 @@ function print_usage {
     echo "  -a  C compiler path. Default: /usr/bin/gcc";
     echo "  -b  C++ compiler path. Default: /usr/bin/g++";
     echo "  -e  List of the LLVM sub-projects to build. Default: clang;openmp";
+    echo "  -v  Enable verbose output";
 }
-while getopts "t:d:p:n:c?i?s?a:b:e:" opt; do
+while getopts "t:d:p:n:c?i?s?a:b:e:v" opt; do
     case "$opt" in
         t)  TARGET=$OPTARG;;
         d)  BUILD_TYPE=$OPTARG;;
@@ -49,6 +51,7 @@ while getopts "t:d:p:n:c?i?s?a:b:e:" opt; do
         a)  C_COMPILER_PATH=$OPTARG;;
         b)  CXX_COMPILER_PATH=$OPTARG;;
         e)  LLVM_ENABLE_PROJECTS=$OPTARG;;
+        v)  VERBOSE="1";;
         ?) print_usage; exit 0;;
     esac
 done
@@ -72,8 +75,12 @@ fi
 
 # Build and install
 mkdir -p build && cd build
+if [ -n "$VERBOSE" ]; then
+  set -x
+fi
 cmake $CMAKE_OPTIONS -DLLVM_ENABLE_PROJECTS=$LLVM_ENABLE_PROJECTS ../llvm
-make -j$NPROC
+set +x
+make -j$NPROC VERBOSE=$VERBOSE
 if [ $DO_INSTALL == "1" ]; then
   if [ $USE_SUDO == "1" ]; then
     echo "Install with sudo"


### PR DESCRIPTION
This PR cherry-picks several workflow-related commits from the `release_14x` and `release_15x` branches, and adds one to change the flang branch used for building/testing the `release_13x` branch.

- [workflows] Build flang's legacy branch instead of master
- [workflows] GitHub CI should build with assertions enabled
- [workflows] Add AArch64 build job
- [workflows] Update branch filter to allow actions on all 'release_*x' branches
- [workflows] Backport CI updates from release_14x