### PR TITLE
[driver] Allow -msve-vector-bits=<n>+ syntax to mean no maximum vscale (release_15x)

### DIFF
--- a/clang/test/Driver/flang/classic-flang-vscale-mbits.f95
+++ b/clang/test/Driver/flang/classic-flang-vscale-mbits.f95
@@ -1,0 +1,28 @@
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve -msve-vector-bits=128 %s 2>&1 | FileCheck -check-prefix=CHECK-SVE-128 %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve -msve-vector-bits=128+ %s 2>&1 | FileCheck -check-prefix=CHECK-SVE-128PLUS %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve -msve-vector-bits=256 %s 2>&1 | FileCheck -check-prefix=CHECK-SVE-256 %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve -msve-vector-bits=256+ %s 2>&1 | FileCheck -check-prefix=CHECK-SVE-256PLUS %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2 -msve-vector-bits=512 %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2-512 %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2 -msve-vector-bits=512+ %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2-512PLUS %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2-sha3 -msve-vector-bits=2048 %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2SHA3-2048 %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2-sha3 -msve-vector-bits=2048+ %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2SHA3-2048PLUS %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2 -msve-vector-bits=scalable %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2-SCALABLE %s
+
+// CHECK-SVE-128: "-target_features" "+neon,+v8a,+sve"
+// CHECK-SVE-128-DAG: "-vscale_range_min" "1" "-vscale_range_max" "1"
+// CHECK-SVE-128PLUS: "-target_features" "+neon,+v8a,+sve"
+// CHECK-SVE-128PLUS-DAG: "-vscale_range_min" "1" "-vscale_range_max" "0"
+// CHECK-SVE-256: "-target_features" "+neon,+v8a,+sve"
+// CHECK-SVE-256-DAG: "-vscale_range_min" "2" "-vscale_range_max" "2"
+// CHECK-SVE-256PLUS: "-target_features" "+neon,+v8a,+sve"
+// CHECK-SVE-256PLUS-DAG: "-vscale_range_min" "2" "-vscale_range_max" "0"
+// CHECK-SVE2-512: "-target_features" "+neon,+v8a,+sve2,+sve"
+// CHECK-SVE2-512-DAG: "-vscale_range_min" "4" "-vscale_range_max" "4"
+// CHECK-SVE2-512PLUS: "-target_features" "+neon,+v8a,+sve2,+sve"
+// CHECK-SVE2-512PLUS-DAG: "-vscale_range_min" "4" "-vscale_range_max" "0"
+// CHECK-SVE2SHA3-2048: "-target_features" "+neon,+v8a,+sve2-sha3,+sve,+sve2"
+// CHECK-SVE2SHA3-2048-DAG: "-vscale_range_min" "16" "-vscale_range_max" "16"
+// CHECK-SVE2SHA3-2048PLUS: "-target_features" "+neon,+v8a,+sve2-sha3,+sve,+sve2"
+// CHECK-SVE2SHA3-2048PLUS-DAG: "-vscale_range_min" "16" "-vscale_range_max" "0"
+// CHECK-SVE2-SCALABLE: "-target_features" "+neon,+v8a,+sve2,+sve"
+// CHECK-SVE2-SCALABLE-DAG: "-vscale_range_min" "1" "-vscale_range_max" "16"

--- a/clang/test/Driver/flang/classic-flang-vscale.f95
+++ b/clang/test/Driver/flang/classic-flang-vscale.f95
@@ -1,0 +1,28 @@
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a %s 2>&1 | FileCheck -check-prefix=CHECK-NEON %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve %s 2>&1 | FileCheck -check-prefix=CHECK-SVE %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2 %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2 %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2-sha3 %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2SHA3 %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve+nosve %s 2>&1 | FileCheck -check-prefix=CHECK-SVE-NOSVE %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2+nosve2-sha3 %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2-NOSVE2SHA3 %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2-sha3+nosve2 %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2SHA3-NOSVE2 %s
+// RUN: %clang --driver-mode=flang -### -S --target=aarch64 -march=armv8-a+sve2-sha3+nosve %s 2>&1 | FileCheck -check-prefix=CHECK-SVE2SHA3-NOSVE %s
+
+// CHECK-NEON: "-target_features" "+neon,+v8a"
+// CHECK-NEON-NOT: "-vscale_range_min"
+// CHECK-NEON-NOT: "-vscale_range_max"
+// CHECK-SVE: "-target_features" "+neon,+v8a,+sve"
+// CHECK-SVE-DAG: "-vscale_range_min" "1" "-vscale_range_max" "16"
+// CHECK-SVE2: "-target_features" "+neon,+v8a,+sve2,+sve"
+// CHECK-SVE2-DAG: "-vscale_range_min" "1" "-vscale_range_max" "16"
+// CHECK-SVE2SHA3: "-target_features" "+neon,+v8a,+sve2-sha3,+sve,+sve2"
+// CHECK-SVE2SHA3-DAG: "-vscale_range_min" "1" "-vscale_range_max" "16"
+// CHECK-SVE-NOSVE: "-target_features" "+neon,+v8a,-sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+// CHECK-SVE-NOSVE-NOT: "-vscale_range_min"
+// CHECK-SVE-NOSVE-NOT: "-vscale_range_max"
+// CHECK-SVE2-NOSVE2SHA3: "-target_features" "+neon,+v8a,+sve2,+sve,-sve2-sha3"
+// CHECK-SVE2-NOSVE2SHA3-DAG: "-vscale_range_min" "1" "-vscale_range_max" "16"
+// CHECK-SVE2SHA3-NOSVE2: "-target_features" "+neon,+v8a,+sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+// CHECK-SVE2SHA3-NOSVE2-DAG: "-vscale_range_min" "1" "-vscale_range_max" "16"
+// CHECK-SVE2SHA3-NOSVE: "-target_features" "+neon,+v8a,-sve,-sve2,-sve2-bitperm,-sve2-sha3,-sve2-aes,-sve2-sm4"
+// CHECK-SVE2SHA3-NOSVE-NOT: "-vscale_range_min"
+// CHECK-SVE2SHA3-NOSVE-NOT: "-vscale_range_max"


### PR DESCRIPTION
`release_15x` version of #137.