### PR TITLE
Setup Windows x64/arm64 GitHub action for Classic Flang LLVM

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -40,29 +40,49 @@ jobs:
           # We're using a specific version of macOS due to:
           # https://github.com/actions/virtual-environments/issues/5900
           - macOS-11
+          - windows-latest
+        include:
+          # Enable Windows on ARM build, when an official
+          # self-hosted machine is available.
+          # - os: self-hosted
+          #   target: AArch64
+          #   arch: arm64
+          - os: windows-latest
+            arch: amd64
+
     steps:
       - name: Setup Windows
-        if: startsWith(matrix.os, 'windows')
+        if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'self')
         uses: llvm/actions/setup-windows@main
         with:
-          arch: amd64
-      # On Windows, starting with win19/20220814.1, cmake choose the 32-bit
-      # python3.10.6 libraries instead of the 64-bit libraries when building
-      # lldb.  Using this setup-python action to make 3.10 the default
-      # python fixes this.
+          arch: ${{ matrix.arch }}
+      # By default CMake chooses the most recent 32-bit libraries instead of
+      # the 64-bit libraries when building and testing LLVM or Clang.
+      # 32 bit version causes a memory error during the testing.
+      # On 'windows-latest' GitHub image (VS2022) 3.11 (32bit) version is installed.
+      # Using this setup-python action to make 3.11 (64bit) the default
       - name: Setup Python
+        if: ${{ matrix.os != 'self-hosted' }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Ninja
         uses: llvm/actions/install-ninja@main
       # actions/checkout deletes any existing files in the new git directory,
       # so this needs to either run before ccache-action or it has to use
       # clean: false.
+      - name: Setup psutil
+        # psutil is not available on Windows on ARM.
+        if: startsWith(matrix.os, 'windows')
+        run: pip install psutil
+      - name: Check tools
+        run: python --version
       - uses: actions/checkout@v3
         with:
           fetch-depth: 250
       - name: Setup ccache
+        # ccache is not available for Windows on ARM.
+        if: ${{ matrix.os != 'self-hosted' }}
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           # A full build of llvm, clang, lld, and lldb takes about 250MB
@@ -74,6 +94,16 @@ jobs:
           # fit under the 10 GB limit.
           max-size: 500M
           key: ${{ matrix.os }}
+      - name: Test clang Windows
+        # Some LLVM tests are failing on Windows On ARM,
+        # so this step is skipped on WoA until they are fixed.
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          $pcount = $($(Get-WmiObject -class Win32_ComputerSystem).numberoflogicalprocessors)
+          python .\scripts\build_llvm_project.py -d build -t ${{ matrix.target }} --cmake-param=-DLLVM_ENABLE_ASSERTIONS=ON -j $pcount
+          cd build
+          ninja check-all
+        shell: powershell
       - name: Test clang macOS
         if: ${{ matrix.os == 'macOS-11'}}
         env:

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Ubuntu Linux
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -80,3 +81,56 @@ jobs:
         with:
           name: llvm_build_${{ matrix.target }}_${{ matrix.cc }}_${{ matrix.version }}_${{ steps.extract_branch.outputs.branch }}
           path: llvm_build.tar.gz
+
+  build-win:
+    name: Windows build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            arch: amd64
+            target: X86
+          # Enable Windows on ARM build, when an official
+          # self-hosted machine is available.
+          # - os: self-hosted
+          #   arch: arm64
+          #   target: AArch64
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Windows
+        uses: llvm/actions/setup-windows@main
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Setup Ninja
+        uses: llvm/actions/install-ninja@main
+
+      - name: Check tools
+        run: |
+          git --version
+          cmake --version
+          clang --version
+          ninja --version
+          python --version
+
+      - name: Extract branch name
+        id: extract_branch
+        run: echo "branch=$(("${{ github.ref }}" -split "/")[-1])" >> $env:GITHUB_OUTPUT
+
+      - name: Build llvm
+        shell: powershell
+        run: |
+          $pcount = $($(Get-WmiObject -class Win32_ComputerSystem).numberoflogicalprocessors)
+          python .\scripts\build_llvm_project.py -d build -t ${{ matrix.target }} --cmake-param=-DLLVM_ENABLE_ASSERTIONS=ON -j $pcount -v
+          cd ..
+          7z a llvm_build.7z $pwd/classic-flang-llvm-project/
+          Copy-Item llvm_build.7z -Destination $pwd/classic-flang-llvm-project/
+
+      - name: Upload llvm
+        uses: actions/upload-artifact@v3
+        with:
+          name: llvm_build_win_${{ matrix.arch }}_clangcl_${{ steps.extract_branch.outputs.branch }}
+          path: ${{ github.workspace }}\llvm_build.7z

--- a/clang/test/Driver/flang/classic-flang.f95
+++ b/clang/test/Driver/flang/classic-flang.f95
@@ -59,17 +59,17 @@
 ! RUN: %flang -target x86_64-linux-gnu -ccc-install-dir %S/../Inputs/basic_linux_tree/usr/bin -static-flang-libs \
 ! RUN:     %s -lfoo -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-FLANG,CHECK-NO-OMP %s
 
-! CHECK-LD:                "{{.*}}ld"
+! CHECK-LD:                "{{.*}}ld{{(.exe)?}}"
 ! CHECK-LD-NOT:            "-static"
-! CHECK-LD:                "{{[^"]*}}classic-flang-{{[^ ]*}}.o" "-lflangmain" "-lfoo" "-L{{[^ ]*}}/basic_linux_tree/usr/lib"
+! CHECK-LD:                "{{[^"]*}}classic-flang-{{[^ ]*}}.o" "-lflangmain" "-lfoo" "-L{{[^ ]*[/\\]+}}basic_linux_tree{{[/\\]+}}usr{{[/\\]+}}lib"
 ! CHECK-DYNAMIC-FLANG-NOT: "-Bstatic"
 ! CHECK-DYNAMIC-FLANG:     "-lflang" "-lflangrti" "-lpgmath" "-lpthread" "-lrt" "-lm"
 ! CHECK-DYNAMIC-FLANG-NOT: "-Bdynamic"
 ! CHECK-STATIC-FLANG:      "-Bstatic" "-lflang" "-lflangrti" "-lpgmath" "-Bdynamic" "-lpthread" "-lrt" "-lm"
 ! CHECK-DYNAMIC-OMP-NOT:   "-Bstatic"
-! CHECK-DYNAMIC-OMP:       "-lomp" "-rpath" "{{[^ ]*}}/basic_linux_tree/usr/lib"
+! CHECK-DYNAMIC-OMP:       "-lomp" "-rpath" "{{[^ ]*[/\\]+}}basic_linux_tree{{[/\\]+}}usr{{[/\\]+}}lib"
 ! CHECK-DYNAMIC-OMP-NOT:   "-Bdynamic"
-! CHECK-STATIC-OMP:        "-Bstatic" "-lomp" "-Bdynamic" "-rpath" "{{[^ ]*}}/basic_linux_tree/usr/lib"
+! CHECK-STATIC-OMP:        "-Bstatic" "-lomp" "-Bdynamic" "-rpath" "{{[^ ]*[/\\]+}}basic_linux_tree{{[/\\]+}}usr{{[/\\]+}}lib"
 ! CHECK-NO-OMP-NOT:        "-lomp"
 
 ! RUN: %flang -target x86_64-linux-gnu -ccc-install-dir %S/../Inputs/basic_linux_tree/usr/bin -static -static-flang-libs \
@@ -78,9 +78,9 @@
 ! RUN:     %s -lfoo -### 2>&1 | FileCheck --check-prefixes=CHECK-LD-STATIC,CHECK-STATIC-BOTH %s
 ! RUN: %flang -target x86_64-linux-gnu -ccc-install-dir %S/../Inputs/basic_linux_tree/usr/bin -static -fopenmp -static-openmp \
 ! RUN:     %s -lfoo -### 2>&1 | FileCheck --check-prefixes=CHECK-LD-STATIC,CHECK-STATIC-BOTH %s
-! CHECK-LD-STATIC:     "{{.*}}ld"
+! CHECK-LD-STATIC:     "{{.*}}ld{{(.exe)?}}"
 ! CHECK-LD-STATIC:     "-static" "-o" "a.out"
-! CHECK-LD-STATIC:     "{{[^"]*}}classic-flang-{{[^ ]*}}.o" "-lflangmain" "-lfoo" "-L{{[^ ]*}}/basic_linux_tree/usr/lib"
+! CHECK-LD-STATIC:     "{{[^"]*}}classic-flang-{{[^ ]*}}.o" "-lflangmain" "-lfoo" "-L{{[^ ]*[/\\]+}}basic_linux_tree{{[/\\]+}}usr{{[/\\]+}}lib"
 ! CHECK-LD-STATIC-NOT: "-Bstatic"
 ! CHECK-LD-STATIC:     "-lflang" "-lflangrti" "-lpgmath" "-lpthread" "-lrt" "-lm"
 ! CHECK-LD-STATIC-NOT: "-Bdynamic"


### PR DESCRIPTION
* Added a GitHub hosted Windows action to produce proper binaries for Flang.
* Enable running tests on Windows x64
* Updated install Python step, since CMake chooses the most recent version of 32bit Python libraries, which is 3.11 on 'windows-latest' GitHub image. Using 32bit version of Python causes a 'memory error' during the tests.

```
[856/859] Building RC object unittests\tools\llvm-mca\CMake-- Testing: 58046 tests, 2 workers --
Exception in thread Thread-13 (_handle_results):
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.11.1\x86\Lib\threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "C:\hostedtoolcache\windows\Python\3.11.1\x86\Lib\threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "C:\hostedtoolcache\windows\Python\3.11.1\x86\Lib\multiprocessing\pool.py", line 579, in _handle_results
    task = get()
           ^^^^^
  File "C:\hostedtoolcache\windows\Python\3.11.1\x86\Lib\multiprocessing\connection.py", line 249, in recv
    buf = self._recv_bytes()
          ^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.11.1\x86\Lib\multiprocessing\connection.py", line 317, in _recv_bytes
    return self._get_more_data(ov, maxsize)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\hostedtoolcache\windows\Python\3.11.1\x86\Lib\multiprocessing\connection.py", line 339, in _get_more_data
    ov, err = _winapi.ReadFile(self._handle, left, overlapped=True)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
MemoryError
```