### PR TITLE
win: Fix the build with verbose options (release_15x)

### DIFF
--- a/scripts/build_llvm_project.py
+++ b/scripts/build_llvm_project.py
@@ -80,7 +80,7 @@ def generate_buildoptions(arguments):
     base_cmake_args.append(f'-DCMAKE_CXX_COMPILER={arguments.cxx}')
 
   if arguments.verbose:
-    base_cmake_args.extend('-DCMAKE_VERBOSE_MAKEFILE=ON')
+    base_cmake_args.append('-DCMAKE_VERBOSE_MAKEFILE=ON')
 
   return base_cmake_args
 


### PR DESCRIPTION
The 'append' method should be used instead of extend, since the 'extend' method treats the arguments as an iterable object, so extends the current list with list of characters.