### PR TITLE
[Driver] Don't use Classic Flang tools for LLVM IR input

### DIFF
--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -175,14 +175,15 @@ bool types::isAcceptedByFlang(ID Id) {
   case TY_PP_F_FreeForm:
   case TY_F_FixedForm:
   case TY_PP_F_FixedForm:
+    return true;
 #else
   case TY_Fortran:
   case TY_PP_Fortran:
-#endif
     return true;
   case TY_LLVM_IR:
   case TY_LLVM_BC:
     return true;
+#endif
   }
 }
 

--- a/clang/test/Driver/flang/llvm-ir-input.f
+++ b/clang/test/Driver/flang/llvm-ir-input.f
@@ -1,0 +1,7 @@
+! Check that LLVM IR input is passed to clang instead of flang1.
+
+! REQUIRES: classic_flang
+! RUN: %clang --driver-mode=flang -S %S/Inputs/llvm-ir-input.ll -### 2>&1 | FileCheck %s
+
+! CHECK-NOT: flang1
+! CHECK: "{{.*}}clang{{.*}}" "-cc1"


### PR DESCRIPTION
LLVM IR input should not be acceptable for Classic Flang tools. This bug was caused by an incorrect merge conflict resolution when upgrading to LLVM 15.