### PR TITLE
Pass Flang libraries to MSVC linker correctly

### DIFF
--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -1201,6 +1201,14 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
     LowerCmdArgs.push_back(Args.MakeArgString(OutFile));
   }
 
+  bool IsWindowsMSVC = getToolChain().getTriple().isWindowsMSVCEnvironment();
+  if (IsWindowsMSVC && !Args.hasArg(options::OPT_noFlangLibs)) {
+    getToolChain().AddFortranStdlibLibArgs(Args, LowerCmdArgs);
+    for (auto Arg : Args.filtered(options::OPT_noFlangLibs)) {
+      Arg->claim();
+    }
+  }
+
   C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::AtFileUTF8(), LowerExec, LowerCmdArgs, Inputs));
 }
 

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -126,7 +126,7 @@ static void renderRemarksHotnessOptions(const ArgList &Args,
 
 #ifdef ENABLE_CLASSIC_FLANG
 /// \brief Determine if Fortran "main" object is needed
-static bool needFortranMain(const Driver &D, const ArgList &Args) {
+bool tools::needFortranMain(const Driver &D, const ArgList &Args) {
   return (needFortranLibs(D, Args)
        && (!Args.hasArg(options::OPT_Mnomain) ||
            !Args.hasArg(options::OPT_no_fortran_main)));

--- a/clang/lib/Driver/ToolChains/CommonArgs.h
+++ b/clang/lib/Driver/ToolChains/CommonArgs.h
@@ -23,6 +23,8 @@ namespace tools {
 
 #ifdef ENABLE_CLASSIC_FLANG
 bool needFortranLibs(const Driver &D, const llvm::opt::ArgList &Args);
+
+bool needFortranMain(const Driver &D, const llvm::opt::ArgList &Args);
 #endif
 
 void addPathIfExists(const Driver &D, const Twine &Path,

--- a/clang/lib/Driver/ToolChains/MSVC.h
+++ b/clang/lib/Driver/ToolChains/MSVC.h
@@ -99,6 +99,11 @@ public:
   void AddHIPRuntimeLibArgs(const llvm::opt::ArgList &Args,
                             llvm::opt::ArgStringList &CmdArgs) const override;
 
+#ifdef ENABLE_CLASSIC_FLANG
+  void AddFortranStdlibLibArgs(const llvm::opt::ArgList &Args,
+                               llvm::opt::ArgStringList &CmdArgs) const override;
+#endif
+
   bool getWindowsSDKLibraryPath(
       const llvm::opt::ArgList &Args, std::string &path) const;
   bool getUniversalCRTLibraryPath(const llvm::opt::ArgList &Args,


### PR DESCRIPTION
The orignal PR was created by Isuruf #65
This change are missing from the recent version of Classic-LLVM.