### PR TITLE
[Driver] Fix flang driver preprocessor issue

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5116,8 +5116,17 @@ class ToolSelector final {
   /// are appended to \a CollapsedOffloadAction.
   void combineWithPreprocessor(const Tool *T, ActionList &Inputs,
                                ActionList &CollapsedOffloadAction) {
+#ifdef ENABLE_CLASSIC_FLANG
+    // flang1 always combines preprocessing and compilation.
+    // Do not return early even when -save-temps is used.
+    if (!T || !T->hasIntegratedCPP() ||
+        (strcmp(T->getName(), "classic-flang") &&
+         !canCollapsePreprocessorAction()))
+      return;
+#else
     if (!T || !canCollapsePreprocessorAction() || !T->hasIntegratedCPP())
       return;
+#endif
 
     // Attempt to get a preprocessor action dependence.
     ActionList PreprocessJobOffloadActions;

--- a/clang/lib/Driver/ToolChains/ClassicFlang.h
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.h
@@ -28,7 +28,7 @@ namespace tools {
 class LLVM_LIBRARY_VISIBILITY ClassicFlang : public Tool {
 public:
   ClassicFlang(const ToolChain &TC)
-      : Tool("flang:frontend",
+      : Tool("classic-flang",
              "Fortran frontend to LLVM", TC) {}
 
   bool hasGoodDiagnostics() const override { return true; }

--- a/clang/test/Driver/fortran-preprocessor.f90
+++ b/clang/test/Driver/fortran-preprocessor.f90
@@ -2,7 +2,7 @@
 
 ! -cpp should preprocess as it goes, regardless of input file extension
 ! RUN: %flang -cpp -c -DHELLO="hello all" -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP,PP
-! RUN: %flang -cpp -c -DHELLO="hello all" -### -c f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP,PP
+! RUN: %flang -cpp -c -DHELLO="hello all" -### -x f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP,PP
 ! -E should preprocess then stop, regardless of input file extension
 ! RUN: %flang -E -DHELLO="hello all" -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
 ! RUN: %flang -E -DHELLO="hello all" -### -x f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
@@ -17,9 +17,9 @@
 
 ! Test -save-temps does not break things (same codepath as -traditional-cpp bug above)
 ! RUN: %flang -E -DHELLO="hello all" -save-temps -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
-! RUN: %flang -E -DHELLO="hello all" -save-temps -### -c f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
-! RUN: %flang -cpp -c -DHELLO="hello all" -save-temps -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP
-! RUN: %flang -cpp -c -DHELLO="hello all" -save-temps -### -c f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP
+! RUN: %flang -E -DHELLO="hello all" -save-temps -### -x f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,E,PPONLY
+! RUN: %flang -cpp -c -DHELLO="hello all" -save-temps -### %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP,PP
+! RUN: %flang -cpp -c -DHELLO="hello all" -save-temps -### -x f95-cpp-input %s 2>&1 | FileCheck %s --check-prefixes=ALL,CPP,PP
 
 ! Test for the correct cmdline flags
 ! Consume up to flang1 line
@@ -31,12 +31,13 @@
 ! E-DAG: "-es"
 ! E-DAG: "-preprocess"
 
-! flang1 should only be called once!
-! ALL-NOT: "{{.*}}flang1"
-
 ! CPP should continue to build object
 ! PP: "{{.*}}flang2"
 ! PPONLY-NOT: "{{.*}}flang2"
+
+! flang1 and flang2 should only be called at most once!
+! ALL-NOT: "{{.*}}flang1"
+! ALL-NOT: "{{.*}}flang2"
 
 ! These commands should never call a linker!
 ! ALL-NOT: "{{.*}}ld"


### PR DESCRIPTION
The `-save-temps` option has been causing the driver to run `flang1`/`flang2` on the input file twice, and the `fortran-preprocessor.f90` test was unable to detect the error, because it had used `-c` instead of `-x` in a couple of `RUN` commands. This patch fixes the test and the driver to make sure that the frontend is not invoked multiple times with `-save-temps`.