### PR TITLE
[Driver] Handle -Mnomain and -fno-fortran-main correctly

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -149,19 +149,14 @@ static bool shouldIgnoreUnsupportedTargetFeature(const Arg &TargetFeatureArg,
 #ifdef ENABLE_CLASSIC_FLANG
 /// \brief Determine if Fortran "main" object is needed
 bool tools::needFortranMain(const Driver &D, const ArgList &Args) {
-  return (needFortranLibs(D, Args)
-       && (!Args.hasArg(options::OPT_Mnomain) ||
-           !Args.hasArg(options::OPT_no_fortran_main)));
+  return (needFortranLibs(D, Args) && !Args.hasArg(options::OPT_Mnomain) &&
+          !Args.hasArg(options::OPT_no_fortran_main));
 }
 
 /// \brief Determine if Fortran link libraies are needed
 bool tools::needFortranLibs(const Driver &D, const ArgList &Args) {
-  if (D.IsFlangMode() && !Args.hasArg(options::OPT_nostdlib) &&
-      !Args.hasArg(options::OPT_noFlangLibs)) {
-    return true;
-  }
-
-  return false;
+  return (D.IsFlangMode() && !Args.hasArg(options::OPT_nostdlib) &&
+          !Args.hasArg(options::OPT_noFlangLibs));
 }
 #endif
 


### PR DESCRIPTION
`-Mnomain` and `-fno-fortran-main` were ineffective unless they were both used at the same time. This patch fixes the bug, formats `needFortranMain` and `needFortranLibs`, and adds some test cases for the logic.