### PR TITLE
[workflows] Fix Ubuntu version in pre-compile_llvm.yml

### DIFF
--- a/.github/workflows/UbuntuDockerfile
+++ b/.github/workflows/UbuntuDockerfile
@@ -34,7 +34,7 @@ RUN apt --fix-missing update && \
     libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev libncurses5-dev && \
     apt install -y python3-distutils python3-psutil \
-    libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+    libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
 
 RUN cd /opt && \
     wget https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-aarch64.sh && \

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Ubuntu Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [X86]


### PR DESCRIPTION
1. The Ubuntu version in pre-compile_llvm.yml should have been updated to 22.04.
2. UbuntuDockerfile should install python3-openssl instead of python-openssl. The latter no longer exists in 22.04.
