### PR TITLE
[workflows] Update GitHub actions to use modern tools (release_16x)

### DIFF
--- a/.github/workflows/UbuntuDockerfile
+++ b/.github/workflows/UbuntuDockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/London
@@ -24,15 +24,9 @@ RUN apt-get update && \
 RUN apt-get install -y software-properties-common && \
     apt-get update && \
     add-apt-repository ppa:ubuntu-toolchain-r/test && \
-    apt-get install -f -y gcc-9 g++-9 && \
-    apt-get install -f -y gcc-10 g++-10 && \
-    echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee -a /etc/apt/sources.list.d/llvm.list && \
-    echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee -a /etc/apt/sources.list.d/llvm.list && \
-    wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    apt-get update && \
-    apt-get install -f -y llvm-9 clang-9 && \
-    apt-get install -f -y llvm-10 clang-10 && \
-    apt-get install -f -y llvm-11 clang-11
+    apt-get install -f -y gcc-12 g++-12 && \
+    apt-get install -f -y llvm-14 clang-14 && \
+    apt-get install -f -y llvm-15 clang-15
 
 # Install the tools for release_13x and newer
 RUN apt --fix-missing update && \
@@ -40,7 +34,7 @@ RUN apt --fix-missing update && \
     libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev libncurses5-dev && \
     apt install -y python3-distutils python3-psutil \
-    libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+    libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl
 
 RUN cd /opt && \
     wget https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-aarch64.sh && \
@@ -57,7 +51,7 @@ RUN if [ "$INITIAL_BUILD" != "true" ]; then \
     mkdir /home/root && cd home/root && \
     git clone --depth 1 --single-branch --branch $BRANCH_NAME https://github.com/flang-compiler/classic-flang-llvm-project.git classic-flang-llvm-project && \
     cd classic-flang-llvm-project && \
-    ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-10 -b /usr/bin/g++-10 -i -x "-DLLVM_ENABLE_ASSERTIONS=ON" -v; \
+    ./build-llvm-project.sh -t AArch64 -p /home/github/usr/local -n `nproc --ignore=1` -a /usr/bin/gcc-12 -b /usr/bin/g++-12 -i -x "-DLLVM_ENABLE_ASSERTIONS=ON" -v; \
     fi
 
 RUN useradd github && \

--- a/.github/workflows/build_push_docker_image_Ubuntu.yml
+++ b/.github/workflows/build_push_docker_image_Ubuntu.yml
@@ -11,8 +11,8 @@ on:
     branches:
       - 'release_*x'
     paths-include:
-      - '**/.github/workflows/build_push_docker_image_Ubuntu20.yml'
-      - '**/.github/workflows/Ubuntu20Dockerfile.yml'
+      - '**/.github/workflows/build_push_docker_image_Ubuntu.yml'
+      - '**/.github/workflows/UbuntuDockerfile.yml'
 
 jobs:
   docker:
@@ -38,11 +38,11 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
-          file: .github/workflows/Ubuntu20Dockerfile
+          file: .github/workflows/UbuntuDockerfile
           push: true
           no-cache: true
           context: .github/workflows
-          tags: ghcr.io/${{ github.repository_owner }}/ubuntu20-flang-${{ steps.extract_branch.outputs.branch }}:latest
+          tags: ghcr.io/${{ github.repository_owner }}/ubuntu-flang-${{ steps.extract_branch.outputs.branch }}:latest
           platforms: linux/arm64
           build-args: |
             BRANCH_NAME=${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/flang-arm64-tests.yml
+++ b/.github/workflows/flang-arm64-tests.yml
@@ -12,7 +12,7 @@ jobs:
       build_path: /home/github
       install_prefix: /home/github/usr/local
     container:
-      image: ghcr.io/${{ github.repository_owner}}/ubuntu20-flang-${{ github.base_ref }}:latest
+      image: ghcr.io/${{ github.repository_owner}}/ubuntu-flang-${{ github.base_ref }}:latest
       credentials:
         username: github
     strategy:
@@ -20,12 +20,12 @@ jobs:
         target: [AArch64]
         cc: [clang]
         cpp: [clang++]
-        version: [10, 11]
+        version: [14, 15]
         include:
           - target: AArch64
             cc: gcc
             cpp: g++
-            version: 10
+            version: 12
 
     steps:
       - name: Check tools

--- a/.github/workflows/flang-tests.yml
+++ b/.github/workflows/flang-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       install_prefix: /usr/local
     strategy:
@@ -15,12 +15,12 @@ jobs:
         target: [X86]
         cc: [clang]
         cpp: [clang++]
-        version: [10, 11]
+        version: [14, 15]
         include:
           - target: X86
             cc: gcc
             cpp: g++
-            version: 10
+            version: 12
 
     steps:
       - uses: actions/checkout@v2
@@ -29,20 +29,15 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
           sudo touch /etc/apt/sources.list.d/llvm.list
-          echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | sudo tee -a /etc/apt/sources.list.d/llvm.list
-          echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'  | sudo tee -a /etc/apt/sources.list.d/llvm.list
-          wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt update
           sudo apt install -f -y llvm-${{ matrix.version }} clang-${{ matrix.version}}
 
-      - if: matrix.cc == 'gcc' && matrix.version == '10'
+      - if: matrix.cc == 'gcc'
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-          sudo apt install gcc-10 g++-10
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 10
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 20
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 10
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 20
+          sudo apt install gcc-${{ matrix.version }} g++-${{ matrix.version }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ matrix.version }} 20
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ matrix.version }} 20
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1

--- a/.github/workflows/pre-compile_llvm.yml
+++ b/.github/workflows/pre-compile_llvm.yml
@@ -9,36 +9,30 @@ on:
 jobs:
   build:
     name: Ubuntu Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [X86]
-        cc: [clang, gcc]
-        version: [10, 11]
+        cc: [clang]
+        cpp: [clang++]
+        version: [14, 15]
+        include:
+          - target: X86
+            cc: gcc
+            cpp: g++
+            version: 12
 
     steps:
       - if: matrix.cc == 'clang'
         run: |
-          echo "cpp=clang++" >> $GITHUB_ENV
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-          sudo touch /etc/apt/sources.list.d/llvm.list
-          echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | sudo tee -a /etc/apt/sources.list.d/llvm.list
-          echo 'deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'  | sudo tee -a /etc/apt/sources.list.d/llvm.list
-          wget -q -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt update
-          sudo apt install -f -y llvm-${{ matrix.version }} clang-${{ matrix.version}}
+          sudo apt install -f -y llvm-${{ matrix.version }} clang-${{ matrix.version }}
 
-      - if: matrix.cc == 'gcc' && matrix.version == '10'
+      - if: matrix.cc == 'gcc'
         run: |
-          echo "cpp=g++" >> $GITHUB_ENV
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-          sudo apt install gcc-10 g++-10
-
-      - if: matrix.cc == 'gcc' && matrix.version == '11'
-        run: |
-          echo "cpp=g++" >> $GITHUB_ENV
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-          sudo apt install gcc-11 g++-11
+          sudo apt install gcc-${{ matrix.version }} g++-${{ matrix.version }}
 
       - name: Check tools
         run: |
@@ -46,7 +40,7 @@ jobs:
           cmake --version
           make --version
           ${{ matrix.cc }}-${{ matrix.version }} --version
-          ${{env.cpp}}-${{ matrix.version }} --version
+          ${{ matrix.cpp }}-${{ matrix.version }} --version
 
       - name: Extract branch name
         run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
@@ -66,7 +60,7 @@ jobs:
             -t ${{ matrix.target }} \
             -p /usr/local \
             -a /usr/bin/${{ matrix.cc }}-${{ matrix.version }} \
-            -b /usr/bin/${{env.cpp}}-${{ matrix.version }} \
+            -b /usr/bin/${{ matrix.cpp }}-${{ matrix.version }} \
             -n $(nproc) \
             -x "-DLLVM_ENABLE_ASSERTIONS=ON" \
             -v


### PR DESCRIPTION
Cherry-pick patches from release_17x, in order to build the release_16x branch of classic-flang-llvm-project and flang with GCC 12 and Clang 14/15 on Ubuntu 22.04. This squashes together the following commits:

    e698fc84 [workflows] Update GitHub actions to use modern tools
    6aeab31b [workflows] Fix GitHub action bugs
    76a4feea [workflows] Fix typo in pre-compile_llvm.yml; NFC

The workflows in the flang repository test both release_16x and release_17x, and keeping the workflows consistent in these classic-flang-llvm-project branches simplifies the flang workflows.