### PR TITLE
[Driver] Allow Classic Flang driver to accept more Clang options

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -167,7 +167,11 @@ def hip_Group : OptionGroup<"<HIP group>">, Group<f_Group>,
 
 def m_Group : OptionGroup<"<m group>">, Group<CompileOnly_Group>,
               DocName<"Target-dependent compilation options">,
+#ifdef ENABLE_CLASSIC_FLANG
+              Visibility<[ClangOption, CLOption, FlangOption]>;
+#else
               Visibility<[ClangOption, CLOption]>;
+#endif
 
 // Feature groups - these take command line options that correspond directly to
 // target specific features and can be translated directly from command line
@@ -199,10 +203,18 @@ def m_wasm_Features_Group : OptionGroup<"<wasm features group>">,
 def m_wasm_Features_Driver_Group : OptionGroup<"<wasm driver features group>">,
                                    Group<m_Group>, DocName<"WebAssembly Driver">;
 def m_x86_Features_Group : OptionGroup<"<x86 features group>">,
+#ifdef ENABLE_CLASSIC_FLANG
+                           Group<m_Group>, Visibility<[ClangOption, CLOption, FlangOption]>,
+#else
                            Group<m_Group>, Visibility<[ClangOption, CLOption]>,
+#endif
                            DocName<"X86">;
 def m_x86_AVX10_Features_Group : OptionGroup<"<x86 AVX10 features group>">,
+#ifdef ENABLE_CLASSIC_FLANG
+                                 Group<m_Group>, Visibility<[ClangOption, CLOption, FlangOption]>,
+#else
                                  Group<m_Group>, Visibility<[ClangOption, CLOption]>,
+#endif
                                  DocName<"X86 AVX10">;
 def m_riscv_Features_Group : OptionGroup<"<riscv features group>">,
                              Group<m_Group>, DocName<"RISC-V">;
@@ -768,10 +780,22 @@ def _DASH_DASH : Option<["--"], "", KIND_REMAINING_ARGS>,
     Flags<[NoXarchOption]>, Visibility<[ClangOption, CLOption, DXCOption]>;
 def A : JoinedOrSeparate<["-"], "A">, Flags<[RenderJoined]>,
   Group<gfortran_Group>;
-def B : JoinedOrSeparate<["-"], "B">, MetaVarName<"<prefix>">,
 #ifdef ENABLE_CLASSIC_FLANG
+def B : JoinedOrSeparate<["-"], "B">, MetaVarName<"<prefix>">,
     Visibility<[ClangOption, FlangOption]>,
-#endif
+    HelpText<"Search $prefix$file for executables, libraries, and data files. "
+    "If $prefix is a directory, search $prefix/$file">;
+def gcc_install_dir_EQ : Joined<["--"], "gcc-install-dir=">,
+  Visibility<[ClangOption, FlangOption]>,
+  HelpText<"Use GCC installation in the specified directory. The directory ends with path components like 'lib{,32,64}/gcc{,-cross}/$triple/$version'. "
+  "Note: executables (e.g. ld) used by the compiler are not overridden by the selected GCC installation">;
+def gcc_toolchain : Joined<["--"], "gcc-toolchain=">, Flags<[NoXarchOption]>,
+  Visibility<[ClangOption, FlangOption]>,
+  HelpText<
+    "Specify a directory where Clang can find 'include' and 'lib{,32,64}/gcc{,-cross}/$triple/$version'. "
+    "Clang will use the GCC installation with the largest version">;
+#else
+def B : JoinedOrSeparate<["-"], "B">, MetaVarName<"<prefix>">,
     HelpText<"Search $prefix$file for executables, libraries, and data files. "
     "If $prefix is a directory, search $prefix/$file">;
 def gcc_install_dir_EQ : Joined<["--"], "gcc-install-dir=">,
@@ -780,6 +804,7 @@ def gcc_install_dir_EQ : Joined<["--"], "gcc-install-dir=">,
 def gcc_toolchain : Joined<["--"], "gcc-toolchain=">, Flags<[NoXarchOption]>,
   HelpText<"Specify a directory where Clang can find 'include' and 'lib{,32,64}/gcc{,-cross}/$triple/$version'. "
   "Clang will use the GCC installation with the largest version">;
+#endif
 def gcc_triple_EQ : Joined<["--"], "gcc-triple=">,
   HelpText<"Search for the GCC installation with the specified triple.">;
 def CC : Flag<["-"], "CC">, Visibility<[ClangOption, CC1Option]>,
@@ -3255,7 +3280,11 @@ defm diagnostics_show_line_numbers : BoolFOption<"diagnostics-show-line-numbers"
 def fno_stack_protector : Flag<["-"], "fno-stack-protector">, Group<f_Group>,
   HelpText<"Disable the use of stack protectors">;
 def fno_strict_aliasing : Flag<["-"], "fno-strict-aliasing">, Group<f_Group>,
+#ifdef ENABLE_CLASSIC_FLANG
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
+#else
   Visibility<[ClangOption, CLOption, DXCOption]>,
+#endif
   HelpText<"Disable optimizations based on strict aliasing rules">;
 def fstruct_path_tbaa : Flag<["-"], "fstruct-path-tbaa">, Group<f_Group>;
 def fno_struct_path_tbaa : Flag<["-"], "fno-struct-path-tbaa">, Group<f_Group>;
@@ -3859,10 +3888,17 @@ def ftrap_function_EQ : Joined<["-"], "ftrap-function=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Issue call to specified function rather than a trap instruction">,
   MarshallingInfoString<CodeGenOpts<"TrapFuncName">>;
+#ifdef ENABLE_CLASSIC_FLANG
+def funroll_loops : Flag<["-"], "funroll-loops">, Group<f_Group>,
+  HelpText<"Turn on loop unroller">, Visibility<[ClangOption, CC1Option, FlangOption]>;
+def fno_unroll_loops : Flag<["-"], "fno-unroll-loops">, Group<f_Group>,
+  HelpText<"Turn off loop unroller">, Visibility<[ClangOption, CC1Option, FlangOption]>;
+#else
 def funroll_loops : Flag<["-"], "funroll-loops">, Group<f_Group>,
   HelpText<"Turn on loop unroller">, Visibility<[ClangOption, CC1Option]>;
 def fno_unroll_loops : Flag<["-"], "fno-unroll-loops">, Group<f_Group>,
   HelpText<"Turn off loop unroller">, Visibility<[ClangOption, CC1Option]>;
+#endif
 defm reroll_loops : BoolFOption<"reroll-loops",
   CodeGenOpts<"RerollLoops">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option], "Turn on loop reroller">,
@@ -4458,17 +4494,29 @@ def mwatchsimulator_version_min_EQ : Joined<["-"], "mwatchsimulator-version-min=
 def march_EQ : Joined<["-"], "march=">, Group<m_Group>,
   Flags<[TargetSpecific]>, Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   HelpText<"For a list of available architectures for the target use '-mcpu=help'">;
+#ifdef ENABLE_CLASSIC_FLANG
+def masm_EQ : Joined<["-"], "masm=">, Group<m_Group>, Visibility<[ClangOption, FlangOption]>;
+#else
 def masm_EQ : Joined<["-"], "masm=">, Group<m_Group>;
+#endif
 def inline_asm_EQ : Joined<["-"], "inline-asm=">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option]>,
   Values<"att,intel">,
   NormalizedValuesScope<"CodeGenOptions">, NormalizedValues<["IAD_ATT", "IAD_Intel"]>,
   MarshallingInfoEnum<CodeGenOpts<"InlineAsmDialect">, "IAD_ATT">;
 def mcmodel_EQ : Joined<["-"], "mcmodel=">, Group<m_Group>,
+#ifdef ENABLE_CLASSIC_FLANG
+  Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
+#else
   Visibility<[ClangOption, CC1Option]>,
+#endif
   MarshallingInfoString<TargetOpts<"CodeModel">, [{"default"}]>;
 def mlarge_data_threshold_EQ : Joined<["-"], "mlarge-data-threshold=">, Group<m_Group>,
+#ifdef ENABLE_CLASSIC_FLANG
+  Flags<[TargetSpecific]>, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
+#else
   Flags<[TargetSpecific]>, Visibility<[ClangOption, CC1Option]>,
+#endif
   MarshallingInfoInt<TargetOpts<"LargeDataThreshold">, "0">;
 def mtls_size_EQ : Joined<["-"], "mtls-size=">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option]>,
@@ -5033,12 +5081,21 @@ def msoft_float : Flag<["-"], "msoft-float">, Group<m_Group>,
 def mno_fmv : Flag<["-"], "mno-fmv">, Group<f_clang_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Disable function multiversioning">;
+#ifdef ENABLE_CLASSIC_FLANG
+def moutline_atomics : Flag<["-"], "moutline-atomics">, Group<f_clang_Group>,
+  Visibility<[ClangOption, CC1Option, FlangOption]>,
+  HelpText<"Generate local calls to out-of-line atomic operations">;
+def mno_outline_atomics : Flag<["-"], "mno-outline-atomics">, Group<f_clang_Group>,
+  Visibility<[ClangOption, CC1Option, FlangOption]>,
+  HelpText<"Don't generate local calls to out-of-line atomic operations">;
+#else
 def moutline_atomics : Flag<["-"], "moutline-atomics">, Group<f_clang_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Generate local calls to out-of-line atomic operations">;
 def mno_outline_atomics : Flag<["-"], "mno-outline-atomics">, Group<f_clang_Group>,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Don't generate local calls to out-of-line atomic operations">;
+#endif
 def mno_implicit_float : Flag<["-"], "mno-implicit-float">, Group<m_Group>,
   HelpText<"Don't generate implicit floating point or vector instructions">;
 def mimplicit_float : Flag<["-"], "mimplicit-float">, Group<m_Group>;
@@ -5369,7 +5426,11 @@ def print_prog_name_EQ : Joined<["-", "--"], "print-prog-name=">,
   Visibility<[ClangOption, CLOption]>;
 def print_resource_dir : Flag<["-", "--"], "print-resource-dir">,
   HelpText<"Print the resource directory pathname">,
+#ifdef ENABLE_CLASSIC_FLANG
+  Visibility<[ClangOption, CLOption, FlangOption]>;
+#else
   Visibility<[ClangOption, CLOption]>;
+#endif
 def print_search_dirs : Flag<["-", "--"], "print-search-dirs">,
   HelpText<"Print the paths used for finding libraries and programs">,
   Visibility<[ClangOption, CLOption]>;
@@ -5406,11 +5467,19 @@ def rdynamic : Flag<["-"], "rdynamic">, Group<Link_Group>,
   Visibility<[ClangOption, FlangOption]>;
 def resource_dir : Separate<["-"], "resource-dir">,
   Flags<[NoXarchOption, HelpHidden]>,
+#ifdef ENABLE_CLASSIC_FLANG
+  Visibility<[ClangOption, CC1Option, CLOption, DXCOption, FlangOption, FC1Option]>,
+#else
   Visibility<[ClangOption, CC1Option, CLOption, DXCOption]>,
+#endif
   HelpText<"The directory which holds the compiler resource files">,
   MarshallingInfoString<HeaderSearchOpts<"ResourceDir">>;
 def resource_dir_EQ : Joined<["-"], "resource-dir=">, Flags<[NoXarchOption]>,
+#ifdef ENABLE_CLASSIC_FLANG
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
+#else
   Visibility<[ClangOption, CLOption, DXCOption]>,
+#endif
   Alias<resource_dir>;
 def rpath : Separate<["-"], "rpath">, Flags<[LinkerInput]>, Group<Link_Group>,
   Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;


### PR DESCRIPTION
This patch cherry-picks a number of Visibility changes from the tip of trunk upstream, to make selected Clang options visible to Classic Flang. It also makes target-specific codegen options (`-mxxxx`) visible to Flang by default. Note that acceptance does not imply support; Classic Flang may simply ignore certain unsupported options (instead of failing) for backward compatibility.

Fixes #181.