### PR TITLE
Making Mbackslash as the default option

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -557,8 +557,11 @@ bool EmitAssemblyHelper::AddEmitPasses(legacy::PassManager &CodeGenPasses,
                                        raw_pwrite_stream &OS,
                                        raw_pwrite_stream *DwoOS) {
   // Add LibraryInfo.
-  std::unique_ptr<TargetLibraryInfoImpl> TLII(
-      llvm::driver::createTLII(TargetTriple, CodeGenOpts.getVecLib()));
+  bool TargetHasAVX512 =
+      std::find(TargetOpts.Features.begin(), TargetOpts.Features.end(),
+                "+avx512f") != TargetOpts.Features.end();
+  std::unique_ptr<TargetLibraryInfoImpl> TLII(llvm::driver::createTLII(
+      TargetTriple, CodeGenOpts.getVecLib(), TargetHasAVX512));
   CodeGenPasses.add(new TargetLibraryInfoWrapperPass(*TLII));
 
   // Normal mode, emit a .s or .o file by running the code generator. Note,
@@ -890,8 +893,11 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
 
   // Register the target library analysis directly and give it a customized
   // preset TLI.
-  std::unique_ptr<TargetLibraryInfoImpl> TLII(
-      llvm::driver::createTLII(TargetTriple, CodeGenOpts.getVecLib()));
+  bool TargetHasAVX512 =
+      std::find(TargetOpts.Features.begin(), TargetOpts.Features.end(),
+                "+avx512f") != TargetOpts.Features.end();
+  std::unique_ptr<TargetLibraryInfoImpl> TLII(llvm::driver::createTLII(
+      TargetTriple, CodeGenOpts.getVecLib(), TargetHasAVX512));
   FAM.registerPass([&] { return TargetLibraryAnalysis(*TLII); });
 
   // Register all the basic analyses with the managers.

--- a/clang/lib/Driver/ToolChains/ClassicFlang.cpp
+++ b/clang/lib/Driver/ToolChains/ClassicFlang.cpp
@@ -240,18 +240,31 @@ void ClassicFlang::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
-  // Treat backslashes as regular characters
-  for (auto Arg : Args.filtered(options::OPT_fno_backslash, options::OPT_Mbackslash)) {
-    Arg->claim();
+  if (auto *A =
+          Args.getLastArg(options::OPT_fno_backslash, options::OPT_Mbackslash,
+                          options::OPT_fbackslash, options::OPT_Mnobackslash)) {
+    for (auto Arg :
+         Args.filtered(options::OPT_fno_backslash, options::OPT_Mbackslash,
+                       options::OPT_fbackslash, options::OPT_Mnobackslash)) {
+      Arg->claim();
+    }
+    // Treat backslashes as regular characters
+    if (A->getOption().matches(options::OPT_fno_backslash) ||
+        A->getOption().matches(options::OPT_Mbackslash)) {
+      CommonCmdArgs.push_back("-x");
+      CommonCmdArgs.push_back("124");
+      CommonCmdArgs.push_back("0x40");
+    }
+    // Treat backslashes as C-style escape characters
+    if (A->getOption().matches(options::OPT_fbackslash) ||
+        A->getOption().matches(options::OPT_Mnobackslash)) {
+      CommonCmdArgs.push_back("-y");
+      CommonCmdArgs.push_back("124");
+      CommonCmdArgs.push_back("0x40");
+    }
+  } else {
+    // By default treat backslashes as regular characters
     CommonCmdArgs.push_back("-x");
-    CommonCmdArgs.push_back("124");
-    CommonCmdArgs.push_back("0x40");
-  }
-
-  // Treat backslashes as C-style escape characters
-  for (auto Arg : Args.filtered(options::OPT_fbackslash, options::OPT_Mnobackslash)) {
-    Arg->claim();
-    CommonCmdArgs.push_back("-y");
     CommonCmdArgs.push_back("124");
     CommonCmdArgs.push_back("0x40");
   }

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -130,6 +130,7 @@ public:
     MASSV,            // IBM MASS vector library.
 #ifdef ENABLE_CLASSIC_FLANG
     PGMATH,           // PGI math library.
+    PGMATH_AVX512,    // PGI math library (AVX512 subset).
 #endif
     SVML,             // Intel short vector math library.
     SLEEFGNUABI, // SLEEF - SIMD Library for Evaluating Elementary Functions.

--- a/llvm/include/llvm/Analysis/VecFuncs.def
+++ b/llvm/include/llvm/Analysis/VecFuncs.def
@@ -1243,418 +1243,437 @@ TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_4", FIXED(4), "_ZGV_LLVM_N4v")
 
 TLI_DEFINE_VECFUNC("__fd_sin_1", "__fd_sin_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_sin_1", "__fd_sin_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_sin_1", "__fd_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_sin_1", "__fs_sin_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_sin_1", "__fs_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_sin_1", "__fs_sin_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_sin_1", "__pd_sin_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_sin_1", "__pd_sin_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_sin_1", "__pd_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_sin_1", "__ps_sin_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_sin_1", "__ps_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_sin_1", "__ps_sin_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_sin_1", "__rd_sin_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_sin_1", "__rd_sin_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_sin_1", "__rd_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_sin_1", "__rs_sin_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_sin_1", "__rs_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_sin_1", "__rs_sin_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_cos_1", "__fd_cos_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_cos_1", "__fd_cos_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_cos_1", "__fd_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_cos_1", "__fs_cos_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_cos_1", "__fs_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_cos_1", "__fs_cos_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_cos_1", "__pd_cos_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_cos_1", "__pd_cos_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_cos_1", "__pd_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_tan_1", "__pd_tan_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_tan_1", "__pd_tan_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_tan_1", "__pd_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_tan_1", "__ps_tan_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_tan_1", "__ps_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_tan_1", "__ps_tan_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_tan_1", "__rd_tan_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_tan_1", "__rd_tan_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_tan_1", "__rd_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_tan_1", "__rs_tan_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_tan_1", "__rs_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_tan_1", "__rs_tan_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_sinh_1", "__fd_sinh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_sinh_1", "__fd_sinh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_sinh_1", "__fd_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_sinh_1", "__fs_sinh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_sinh_1", "__fs_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_sinh_1", "__fs_sinh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_sinh_1", "__pd_sinh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_sinh_1", "__pd_sinh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_sinh_1", "__pd_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_sinh_1", "__ps_sinh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_sinh_1", "__ps_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_sinh_1", "__ps_sinh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_sinh_1", "__rd_sinh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_sinh_1", "__rd_sinh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_sinh_1", "__rd_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_sinh_1", "__rs_sinh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_sinh_1", "__rs_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_sinh_1", "__rs_sinh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_cosh_1", "__fd_cosh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_cosh_1", "__fd_cosh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_cosh_1", "__fd_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_cosh_1", "__fs_cosh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_cosh_1", "__fs_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_cosh_1", "__fs_cosh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_cosh_1", "__pd_cosh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_cosh_1", "__pd_cosh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_cosh_1", "__pd_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_cosh_1", "__ps_cosh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_cosh_1", "__ps_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_cosh_1", "__ps_cosh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_cosh_1", "__rd_cosh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_cosh_1", "__rd_cosh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_cosh_1", "__rd_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_cosh_1", "__rs_cosh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_cosh_1", "__rs_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_cosh_1", "__rs_cosh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_tanh_1", "__fd_tanh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_tanh_1", "__fd_tanh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_tanh_1", "__fd_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_tanh_1", "__fs_tanh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_tanh_1", "__fs_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_tanh_1", "__fs_tanh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_tanh_1", "__pd_tanh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_tanh_1", "__pd_tanh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_tanh_1", "__pd_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_tanh_1", "__ps_tanh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_tanh_1", "__ps_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_tanh_1", "__ps_tanh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_tanh_1", "__rd_tanh_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_tanh_1", "__rd_tanh_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_tanh_1", "__rd_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_tanh_1", "__rs_tanh_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_tanh_1", "__rs_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_tanh_1", "__rs_tanh_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_asin_1", "__fd_asin_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_asin_1", "__fd_asin_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_asin_1", "__fd_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_asin_1", "__fs_asin_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_asin_1", "__fs_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_asin_1", "__fs_asin_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_asin_1", "__pd_asin_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_asin_1", "__pd_asin_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_asin_1", "__pd_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_asin_1", "__ps_asin_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_asin_1", "__ps_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_asin_1", "__ps_asin_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_asin_1", "__rd_asin_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_asin_1", "__rd_asin_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_asin_1", "__rd_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_asin_1", "__rs_asin_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_asin_1", "__rs_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_asin_1", "__rs_asin_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_acos_1", "__fd_acos_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_acos_1", "__fd_acos_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_acos_1", "__fd_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_acos_1", "__fs_acos_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_acos_1", "__fs_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_acos_1", "__fs_acos_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_acos_1", "__pd_acos_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_acos_1", "__pd_acos_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_acos_1", "__pd_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_acos_1", "__ps_acos_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_acos_1", "__ps_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_acos_1", "__ps_acos_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_acos_1", "__rd_acos_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_acos_1", "__rd_acos_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_acos_1", "__rd_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_acos_1", "__rs_acos_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_acos_1", "__rs_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_acos_1", "__rs_acos_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_atan_1", "__fd_atan_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_atan_1", "__fd_atan_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_atan_1", "__fd_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_atan_1", "__fs_atan_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_atan_1", "__fs_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_atan_1", "__fs_atan_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_atan_1", "__pd_atan_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_atan_1", "__pd_atan_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_atan_1", "__pd_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_atan_1", "__ps_atan_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_atan_1", "__ps_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_atan_1", "__ps_atan_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_atan_1", "__rd_atan_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_atan_1", "__rd_atan_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_atan_1", "__rd_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_atan_1", "__rs_atan_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_atan_1", "__rs_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_atan_1", "__rs_atan_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_atan2_1", "__fd_atan2_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__fd_atan2_1", "__fd_atan2_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__fd_atan2_1", "__fd_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__fs_atan2_1", "__fs_atan2_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__fs_atan2_1", "__fs_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__fs_atan2_1", "__fs_atan2_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__pd_atan2_1", "__pd_atan2_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__pd_atan2_1", "__pd_atan2_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__pd_atan2_1", "__pd_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__ps_atan2_1", "__ps_atan2_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__ps_atan2_1", "__ps_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__ps_atan2_1", "__ps_atan2_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__rd_atan2_1", "__rd_atan2_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__rd_atan2_1", "__rd_atan2_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__rd_atan2_1", "__rd_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__rs_atan2_1", "__rs_atan2_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__rs_atan2_1", "__rs_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__rs_atan2_1", "__rs_atan2_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__fd_pow_1", "__fd_pow_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__fd_pow_1", "__fd_pow_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__fd_pow_1", "__fd_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__fs_pow_1", "__fs_pow_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__fs_pow_1", "__fs_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__fs_pow_1", "__fs_pow_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__pd_pow_1", "__pd_pow_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__pd_pow_1", "__pd_pow_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__pd_pow_1", "__pd_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__ps_pow_1", "__ps_pow_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__ps_pow_1", "__ps_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__ps_pow_1", "__ps_pow_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__rd_pow_1", "__rd_pow_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__rd_pow_1", "__rd_pow_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__rd_pow_1", "__rd_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__rs_pow_1", "__rs_pow_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__rs_pow_1", "__rs_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__rs_pow_1", "__rs_pow_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__fs_powi_1", "__fs_powi_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__fs_powi_1", "__fs_powi_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__fs_powi_1", "__fs_powi_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__ps_powi_1", "__ps_powi_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__ps_powi_1", "__ps_powi_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__ps_powi_1", "__ps_powi_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__rs_powi_1", "__rs_powi_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__rs_powi_1", "__rs_powi_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__rs_powi_1", "__rs_powi_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__fd_powi1_1", "__fd_powi1_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__fd_powi1_1", "__fd_powi1_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__fd_powi1_1", "__fd_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__fs_powi1_1", "__fs_powi1_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__fs_powi1_1", "__fs_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__fs_powi1_1", "__fs_powi1_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__pd_powi1_1", "__pd_powi1_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__pd_powi1_1", "__pd_powi1_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__pd_powi1_1", "__pd_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__ps_powi1_1", "__ps_powi1_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__ps_powi1_1", "__ps_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__ps_powi1_1", "__ps_powi1_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__rd_powi1_1", "__rd_powi1_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__rd_powi1_1", "__rd_powi1_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__rd_powi1_1", "__rd_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__rs_powi1_1", "__rs_powi1_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__rs_powi1_1", "__rs_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__rs_powi1_1", "__rs_powi1_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__fd_powk_1", "__fd_powk_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__fd_powk_1", "__fd_powk_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__fd_powk_1", "__fd_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__fs_powk_1", "__fs_powk_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__fs_powk_1", "__fs_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__fs_powk_1", "__fs_powk_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__pd_powk_1", "__pd_powk_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__pd_powk_1", "__pd_powk_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__pd_powk_1", "__pd_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__ps_powk_1", "__ps_powk_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__ps_powk_1", "__ps_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__ps_powk_1", "__ps_powk_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__rd_powk_1", "__rd_powk_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__rd_powk_1", "__rd_powk_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__rd_powk_1", "__rd_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__rs_powk_1", "__rs_powk_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__rs_powk_1", "__rs_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__rs_powk_1", "__rs_powk_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__fd_powk1_1", "__fd_powk1_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__fd_powk1_1", "__fd_powk1_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__fd_powk1_1", "__fd_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__fs_powk1_1", "__fs_powk1_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__fs_powk1_1", "__fs_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__fs_powk1_1", "__fs_powk1_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__pd_powk1_1", "__pd_powk1_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__pd_powk1_1", "__pd_powk1_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__pd_powk1_1", "__pd_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__ps_powk1_1", "__ps_powk1_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__ps_powk1_1", "__ps_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__ps_powk1_1", "__ps_powk1_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__rd_powk1_1", "__rd_powk1_2", FIXED(2), "_ZGV_LLVM_N2vv")
 TLI_DEFINE_VECFUNC("__rd_powk1_1", "__rd_powk1_4", FIXED(4), "_ZGV_LLVM_N4vv")
-TLI_DEFINE_VECFUNC("__rd_powk1_1", "__rd_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
 
 TLI_DEFINE_VECFUNC("__rs_powk1_1", "__rs_powk1_4", FIXED(4), "_ZGV_LLVM_N4vv")
 TLI_DEFINE_VECFUNC("__rs_powk1_1", "__rs_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
-TLI_DEFINE_VECFUNC("__rs_powk1_1", "__rs_powk1_16", FIXED(16), "_ZGV_LLVM_N16vv")
 
 TLI_DEFINE_VECFUNC("__fd_log10_1", "__fd_log10_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_log10_1", "__fd_log10_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_log10_1", "__fd_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_log10_1", "__fs_log10_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_log10_1", "__fs_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_log10_1", "__fs_log10_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_log10_1", "__pd_log10_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_log10_1", "__pd_log10_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_log10_1", "__pd_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_log10_1", "__ps_log10_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_log10_1", "__ps_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_log10_1", "__ps_log10_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_log10_1", "__rd_log10_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_log10_1", "__rd_log10_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_log10_1", "__rd_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_log10_1", "__rs_log10_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_log10_1", "__rs_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_log10_1", "__rs_log10_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fd_log_1", "__fd_log_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__fd_log_1", "__fd_log_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__fd_log_1", "__fd_log_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__fs_log_1", "__fs_log_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_log_1", "__fs_log_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_log_1", "__fs_log_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_log_1", "__pd_log_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_log_1", "__pd_log_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_log_1", "__pd_log_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_log_1", "__ps_log_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_log_1", "__ps_log_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_log_1", "__ps_log_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_log_1", "__rd_log_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_log_1", "__rd_log_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_log_1", "__rd_log_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_log_1", "__rs_log_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_log_1", "__rs_log_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__rs_log_1", "__rs_log_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__fs_exp_1", "__fs_exp_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__fs_exp_1", "__fs_exp_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__fs_exp_1", "__fs_exp_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__pd_exp_1", "__pd_exp_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__pd_exp_1", "__pd_exp_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__pd_exp_1", "__pd_exp_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__ps_exp_1", "__ps_exp_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__ps_exp_1", "__ps_exp_8", FIXED(8), "_ZGV_LLVM_N8v")
-TLI_DEFINE_VECFUNC("__ps_exp_1", "__ps_exp_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 TLI_DEFINE_VECFUNC("__rd_exp_1", "__rd_exp_2", FIXED(2), "_ZGV_LLVM_N2v")
 TLI_DEFINE_VECFUNC("__rd_exp_1", "__rd_exp_4", FIXED(4), "_ZGV_LLVM_N4v")
-TLI_DEFINE_VECFUNC("__rd_exp_1", "__rd_exp_8", FIXED(8), "_ZGV_LLVM_N8v")
 
 TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_4", FIXED(4), "_ZGV_LLVM_N4v")
 TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_8", FIXED(8), "_ZGV_LLVM_N8v")
+
+#elif defined(TLI_DEFINE_PGMATH_X86_AVX512_VECFUNCS)
+TLI_DEFINE_VECFUNC("__fd_sin_1", "__fd_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_sin_1", "__fs_sin_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_sin_1", "__pd_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_sin_1", "__ps_sin_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_sin_1", "__rd_sin_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_sin_1", "__rs_sin_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_cos_1", "__fd_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_cos_1", "__fs_cos_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_cos_1", "__pd_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_cos_1", "__ps_cos_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_cos_1", "__rd_cos_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_cos_1", "__rs_cos_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_tan_1", "__fd_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_tan_1", "__fs_tan_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_tan_1", "__pd_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_tan_1", "__ps_tan_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_tan_1", "__rd_tan_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_tan_1", "__rs_tan_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_sinh_1", "__fd_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_sinh_1", "__fs_sinh_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_sinh_1", "__pd_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_sinh_1", "__ps_sinh_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_sinh_1", "__rd_sinh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_sinh_1", "__rs_sinh_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_cosh_1", "__fd_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_cosh_1", "__fs_cosh_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_cosh_1", "__pd_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_cosh_1", "__ps_cosh_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_cosh_1", "__rd_cosh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_cosh_1", "__rs_cosh_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_tanh_1", "__fd_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_tanh_1", "__fs_tanh_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_tanh_1", "__pd_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_tanh_1", "__ps_tanh_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_tanh_1", "__rd_tanh_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_tanh_1", "__rs_tanh_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_asin_1", "__fd_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_asin_1", "__fs_asin_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_asin_1", "__pd_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_asin_1", "__ps_asin_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_asin_1", "__rd_asin_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_asin_1", "__rs_asin_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_acos_1", "__fd_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_acos_1", "__fs_acos_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_acos_1", "__pd_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_acos_1", "__ps_acos_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_acos_1", "__rd_acos_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_acos_1", "__rs_acos_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_atan_1", "__fd_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_atan_1", "__fs_atan_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_atan_1", "__pd_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_atan_1", "__ps_atan_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_atan_1", "__rd_atan_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_atan_1", "__rs_atan_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_atan2_1", "__fd_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__fs_atan2_1", "__fs_atan2_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__pd_atan2_1", "__pd_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__ps_atan2_1", "__ps_atan2_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__rd_atan2_1", "__rd_atan2_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__rs_atan2_1", "__rs_atan2_16", FIXED(16), "_ZGV_LLVM_N16vv")
+
+TLI_DEFINE_VECFUNC("__fd_pow_1", "__fd_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__fs_pow_1", "__fs_pow_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__pd_pow_1", "__pd_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__ps_pow_1", "__ps_pow_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__rd_pow_1", "__rd_pow_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__rs_pow_1", "__rs_pow_16", FIXED(16), "_ZGV_LLVM_N16vv")
+
+TLI_DEFINE_VECFUNC("__fs_powi_1", "__fs_powi_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__ps_powi_1", "__ps_powi_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__rs_powi_1", "__rs_powi_16", FIXED(16), "_ZGV_LLVM_N16vv")
+
+TLI_DEFINE_VECFUNC("__fd_powi1_1", "__fd_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__fs_powi1_1", "__fs_powi1_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__pd_powi1_1", "__pd_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__ps_powi1_1", "__ps_powi1_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__rd_powi1_1", "__rd_powi1_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__rs_powi1_1", "__rs_powi1_16", FIXED(16), "_ZGV_LLVM_N16vv")
+
+TLI_DEFINE_VECFUNC("__fd_powk_1", "__fd_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__fs_powk_1", "__fs_powk_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__pd_powk_1", "__pd_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__ps_powk_1", "__ps_powk_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__rd_powk_1", "__rd_powk_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__rs_powk_1", "__rs_powk_16", FIXED(16), "_ZGV_LLVM_N16vv")
+
+TLI_DEFINE_VECFUNC("__fd_powk1_1", "__fd_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__fs_powk1_1", "__fs_powk1_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__pd_powk1_1", "__pd_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__ps_powk1_1", "__ps_powk1_16", FIXED(16), "_ZGV_LLVM_N16vv")
+TLI_DEFINE_VECFUNC("__rd_powk1_1", "__rd_powk1_8", FIXED(8), "_ZGV_LLVM_N8vv")
+TLI_DEFINE_VECFUNC("__rs_powk1_1", "__rs_powk1_16", FIXED(16), "_ZGV_LLVM_N16vv")
+
+TLI_DEFINE_VECFUNC("__fd_log10_1", "__fd_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_log10_1", "__fs_log10_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_log10_1", "__pd_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_log10_1", "__ps_log10_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_log10_1", "__rd_log10_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_log10_1", "__rs_log10_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fd_log_1", "__fd_log_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__fs_log_1", "__fs_log_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_log_1", "__pd_log_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_log_1", "__ps_log_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_log_1", "__rd_log_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__rs_log_1", "__rs_log_16", FIXED(16), "_ZGV_LLVM_N16v")
+
+TLI_DEFINE_VECFUNC("__fs_exp_1", "__fs_exp_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__pd_exp_1", "__pd_exp_8", FIXED(8), "_ZGV_LLVM_N8v")
+TLI_DEFINE_VECFUNC("__ps_exp_1", "__ps_exp_16", FIXED(16), "_ZGV_LLVM_N16v")
+TLI_DEFINE_VECFUNC("__rd_exp_1", "__rd_exp_8", FIXED(8), "_ZGV_LLVM_N8v")
 TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_16", FIXED(16), "_ZGV_LLVM_N16v")
 
 #else
@@ -1679,3 +1698,4 @@ TLI_DEFINE_VECFUNC("__rs_exp_1", "__rs_exp_16", FIXED(16), "_ZGV_LLVM_N16v")
 #undef TLI_DEFINE_ARMPL_VECFUNCS
 #undef TLI_DEFINE_PGMATH_AARCH64_VECFUNCS
 #undef TLI_DEFINE_PGMATH_X86_VECFUNCS
+#undef TLI_DEFINE_PGMATH_X86_AVX512_VECFUNCS

--- a/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
+++ b/llvm/include/llvm/Frontend/Driver/CodeGenOptions.h
@@ -36,7 +36,8 @@ enum class VectorLibrary {
 };
 
 TargetLibraryInfoImpl *createTLII(llvm::Triple &TargetTriple,
-                                  VectorLibrary Veclib);
+                                  VectorLibrary Veclib,
+				  bool targetAVX512);
 
 } // end namespace llvm::driver
 

--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -35,6 +35,8 @@ static cl::opt<TargetLibraryInfoImpl::VectorLibrary> ClVectorLibrary(
 #ifdef ENABLE_CLASSIC_FLANG
                clEnumValN(TargetLibraryInfoImpl::PGMATH, "PGMATH",
                           "PGI math library"),
+               clEnumValN(TargetLibraryInfoImpl::PGMATH_AVX512, "PGMATH_AVX512",
+                          "PGI math library (AVX512)"),
 #endif
                clEnumValN(TargetLibraryInfoImpl::SVML, "SVML",
                           "Intel SVML library"),
@@ -1299,6 +1301,15 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
     }
     break;
   }
+  case PGMATH_AVX512: {
+     const VecDesc VecFuncs[] = {
+     #define TLI_DEFINE_PGMATH_X86_AVX512_VECFUNCS
+     #include "llvm/Analysis/VecFuncs.def"
+     };
+     addVectorizableFunctions(VecFuncs);
+
+     break;
+   }
 #endif
 
   case NoLibrary:

--- a/llvm/lib/Frontend/Driver/CodeGenOptions.cpp
+++ b/llvm/lib/Frontend/Driver/CodeGenOptions.cpp
@@ -13,7 +13,8 @@
 namespace llvm::driver {
 
 TargetLibraryInfoImpl *createTLII(llvm::Triple &TargetTriple,
-                                  driver::VectorLibrary Veclib) {
+                                  driver::VectorLibrary Veclib,
+                                  bool TargetHasAVX512) {
   TargetLibraryInfoImpl *TLII = new TargetLibraryInfoImpl(TargetTriple);
 
   using VectorLibrary = llvm::driver::VectorLibrary;
@@ -34,7 +35,11 @@ TargetLibraryInfoImpl *createTLII(llvm::Triple &TargetTriple,
   case VectorLibrary::PGMATH:
     TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::PGMATH,
                                              TargetTriple);
+    if (TargetHasAVX512)
+      TLII->addVectorizableFunctionsFromVecLib(
+          TargetLibraryInfoImpl::PGMATH_AVX512, TargetTriple);
     break;
+
 #endif
   case VectorLibrary::SVML:
     TLII->addVectorizableFunctionsFromVecLib(TargetLibraryInfoImpl::SVML,


### PR DESCRIPTION
Fix for issue 1440 (#180)

    Through this commit Mbackslash will be the default option.
    By default, escape characters are treated as regular characters unless Mnobackslash
    is specified.

    There is also the issue of treating both Mbackslash and Mnobackslash options independently.
    This is addressed in this patch and the testcases in flang repository will test this feature.
