### PR TITLE
[workflows] Upgrade GitHub runner to macOS-13

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -40,10 +40,8 @@ jobs:
         target: [X86]
         os:
           - ubuntu-latest
-          # We're using a specific version of macOS due to:
-          # https://github.com/actions/virtual-environments/issues/5900
-          - macOS-11
           - windows-latest
+          - macOS-13
         include:
           # Enable Windows on ARM build, when an official
           # self-hosted machine is available.
@@ -108,7 +106,7 @@ jobs:
           ninja check-all
         shell: powershell
       - name: Test clang macOS
-        if: ${{ matrix.os == 'macOS-11'}}
+        if: ${{ matrix.os == 'macOS-13'}}
         env:
           # Workaround for https://github.com/actions/virtual-environments/issues/5900.
           # This should be a no-op for non-mac OSes


### PR DESCRIPTION
GitHub has stopped supporting macOS-11, causing our workflows to wait indefinitely for an unavailable runner.

Cherry-picking a CI patch to release_17x so that we can build this branch and give it a final tag.