### PR TITLE
Do not use preprocessor directives in omp_lib.h

### DIFF
--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -340,14 +340,14 @@ endif()
 # Building the Fortran module files
 # One compilation step creates both omp_lib.mod and omp_lib_kinds.mod
 configure_file(${LIBOMP_INC_DIR}/omp_lib.h.var omp_lib.h @ONLY)
-configure_file(${LIBOMP_INC_DIR}/omp_lib.F90.var omp_lib.F90 @ONLY)
+configure_file(${LIBOMP_INC_DIR}/omp_lib.f90.var omp_lib.f90 @ONLY)
 
 set(BUILD_FORTRAN_MODULES False)
 if (NOT ${LIBOMP_FORTRAN_MODULES_COMPILER} STREQUAL "")
   # If libomp is built as an LLVM runtime and the flang compiler is available,
   # compile the Fortran module files.
   message(STATUS "configuring openmp to build Fortran module files using ${LIBOMP_FORTRAN_MODULES_COMPILER}")
-  set(LIBOMP_FORTRAN_SOURCE_FILE omp_lib.F90)
+  set(LIBOMP_FORTRAN_SOURCE_FILE omp_lib.f90)
   add_custom_target(libomp-mod ALL DEPENDS omp_lib.mod omp_lib_kinds.mod)
   add_custom_command(
     OUTPUT omp_lib.mod omp_lib_kinds.mod
@@ -367,7 +367,7 @@ elseif(${LIBOMP_FORTRAN_MODULES})
   set_target_properties(libomp-mod PROPERTIES FOLDER "OpenMP/Misc")
   libomp_get_fflags(LIBOMP_CONFIGURED_FFLAGS)
   if(CMAKE_Fortran_COMPILER_SUPPORTS_F90)
-    set(LIBOMP_FORTRAN_SOURCE_FILE omp_lib.F90)
+    set(LIBOMP_FORTRAN_SOURCE_FILE omp_lib.f90)
   else()
     message(FATAL_ERROR "Fortran module build requires Fortran 90 compiler")
   endif()

--- a/openmp/runtime/src/include/omp_lib.f90.var
+++ b/openmp/runtime/src/include/omp_lib.f90.var
@@ -429,102 +429,82 @@
           end subroutine omp_fulfill_event
 
           subroutine omp_init_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_init_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_lock_kind) svar
           end subroutine omp_init_lock
 
           subroutine omp_destroy_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_destroy_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_lock_kind) svar
           end subroutine omp_destroy_lock
 
           subroutine omp_set_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_set_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_lock_kind) svar
           end subroutine omp_set_lock
 
           subroutine omp_unset_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_unset_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_lock_kind) svar
           end subroutine omp_unset_lock
 
           function omp_test_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_test_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             logical (kind=omp_logical_kind) omp_test_lock
             integer (kind=omp_lock_kind) svar
           end function omp_test_lock
 
           subroutine omp_init_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_init_nest_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_nest_lock_kind) nvar
           end subroutine omp_init_nest_lock
 
           subroutine omp_destroy_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_destroy_nest_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_nest_lock_kind) nvar
           end subroutine omp_destroy_nest_lock
 
           subroutine omp_set_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_set_nest_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_nest_lock_kind) nvar
           end subroutine omp_set_nest_lock
 
           subroutine omp_unset_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_unset_nest_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_nest_lock_kind) nvar
           end subroutine omp_unset_nest_lock
 
           function omp_test_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_test_nest_lock
 !DIR$ ENDIF
-#endif
             use omp_lib_kinds
             integer (kind=omp_integer_kind) omp_test_nest_lock
             integer (kind=omp_nest_lock_kind) nvar

--- a/openmp/runtime/src/include/omp_lib.h.var
+++ b/openmp/runtime/src/include/omp_lib.h.var
@@ -486,102 +486,82 @@
         end subroutine omp_fulfill_event
 
         subroutine omp_init_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_init_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_lock_kind) svar
         end subroutine omp_init_lock
 
         subroutine omp_destroy_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_destroy_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_lock_kind) svar
         end subroutine omp_destroy_lock
 
         subroutine omp_set_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_set_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_lock_kind) svar
         end subroutine omp_set_lock
 
         subroutine omp_unset_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_unset_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_lock_kind) svar
         end subroutine omp_unset_lock
 
         function omp_test_lock(svar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_test_lock
 !DIR$ ENDIF
-#endif
           import
           logical (kind=omp_logical_kind) omp_test_lock
           integer (kind=omp_lock_kind) svar
         end function omp_test_lock
 
         subroutine omp_init_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_init_nest_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_nest_lock_kind) nvar
         end subroutine omp_init_nest_lock
 
         subroutine omp_destroy_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_destroy_nest_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_nest_lock_kind) nvar
         end subroutine omp_destroy_nest_lock
 
         subroutine omp_set_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_set_nest_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_nest_lock_kind) nvar
         end subroutine omp_set_nest_lock
 
         subroutine omp_unset_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_unset_nest_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_nest_lock_kind) nvar
         end subroutine omp_unset_nest_lock
 
         function omp_test_nest_lock(nvar) bind(c)
-#ifdef __INTEL_COMPILER
 !DIR$ IF(__INTEL_COMPILER.GE.1400)
 !DIR$ attributes known_intrinsic :: omp_test_nest_lock
 !DIR$ ENDIF
-#endif
           import
           integer (kind=omp_integer_kind) omp_test_nest_lock
           integer (kind=omp_nest_lock_kind) nvar
@@ -1010,7 +990,6 @@
         end subroutine kmp_set_warnings_off
       end interface
 
-#ifdef __INTEL_COMPILER
 !DIR$ IF DEFINED (__INTEL_OFFLOAD)
 
 !DIR$ IF(__INTEL_COMPILER.LT.1900)
@@ -1179,4 +1158,3 @@
 !$omp declare target(omp_init_nest_lock_with_hint )
 !DIR$ ENDIF
 !DIR$ ENDIF
-#endif


### PR DESCRIPTION
This partially reverts commit fb5fd2d82f9befba9cf5152d1a0c5e6f91ee48f0, in order to remove the use of preprocessor directives in omp_lib.h, which causes the Classic Flang frontend to fail when the including source file is not preprocessed.

Closes flang-compiler/flang#1451.